### PR TITLE
F2F: Amended incorrect tag value

### DIFF
--- a/infra-l2-dynamo/template.yaml
+++ b/infra-l2-dynamo/template.yaml
@@ -106,7 +106,7 @@ Resources:
         - Key: Product
           Value: Gov.UK Sign On
         - Key: System
-          Value: Claimed Identity Collector
+          Value: IPV Return Service
         - Key: Environment
           Value: !Ref Environment
 


### PR DESCRIPTION
### What changed

Changed incorrect tag value to read "IPV Return" rather than "Claimed Identity Collector" which is not the service pertaining to this repo

