### PR TITLE
F2F-530: Add sonar scan to ipvreturn-api

### DIFF
--- a/.github/workflows/pull-request-sonar.yml
+++ b/.github/workflows/pull-request-sonar.yml
@@ -1,4 +1,4 @@
-name: Sonar Analysis on Merge
+name: Pull Request CI - Sonar
 on:
   workflow_dispatch:
   push:

--- a/.github/workflows/sonar-analysis-on-merge.yml
+++ b/.github/workflows/sonar-analysis-on-merge.yml
@@ -1,0 +1,40 @@
+name: Sonar Analysis on Merge
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - ready_for_review
+      - synchronize
+
+jobs:
+  run-code-analysis:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
+        working-directory: src/
+    steps:
+      - name: "Checkout code"
+        uses: "actions/checkout@v3"
+        with:
+          fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
+      - name: Setup nodeJS v18
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
+      - name: Install dependencies
+        run: npm install
+      - name: Test and coverage
+        run: npm run test:unit -- --coverage
+      - name: Run Infra checks
+        run: npm run test:infra
+      - name: "Run SonarCloud Scan"
+        if: ${{ success() }}
+        uses: SonarSource/sonarcloud-github-action@master
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/sonar-analysis-on-merge.yml
+++ b/.github/workflows/sonar-analysis-on-merge.yml
@@ -1,5 +1,6 @@
 name: Sonar Analysis on Merge
 on:
+  workflow_dispatch:
   push:
     branches:
       - main
@@ -30,8 +31,6 @@ jobs:
         run: npm install
       - name: Test and coverage
         run: npm run test:unit -- --coverage
-      - name: Run Infra checks
-        run: npm run test:infra
       - name: "Run SonarCloud Scan"
         if: ${{ success() }}
         uses: SonarSource/sonarcloud-github-action@master

--- a/infra-l2-dynamo/jest.config.ts
+++ b/infra-l2-dynamo/jest.config.ts
@@ -17,7 +17,8 @@ export default {
     'default',
     ['jest-junit', { outputDirectory: 'results', outputName: 'report.xml' }]
   ],
-  collectCoverage: false,
+  collectCoverage: true,
+  coverageDirectory: "coverage",
   coverageProvider: 'v8',
   testMatch: ['**/*.test.ts'],
   testEnvironment: 'node'

--- a/infra-l2-kms/jest.config.ts
+++ b/infra-l2-kms/jest.config.ts
@@ -17,7 +17,8 @@ export default {
     'default',
     ['jest-junit', { outputDirectory: 'results', outputName: 'report.xml' }]
   ],
-  collectCoverage: false,
+  collectCoverage: true,
+  coverageDirectory: "coverage",
   coverageProvider: 'v8',
   testMatch: ['**/*.test.ts'],
   testEnvironment: 'node'

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,16 @@
+sonar.projectKey=alphagov_di-ipvreturn-api
+sonar.organization=alphagov
+
+# This is the name and version displayed in the SonarCloud UI.
+#sonar.projectVersion=1.0
+
+# Path is relative to the sonar-project.properties file. Replace "\" by "/" on Windows.
+sonar.sources=src/
+sonar.exclusions=tests/**/*.*,jest.config.ts,src/jest.setup.ts
+sonar.tests=src/
+sonar.test.inclusions=**/*.test.ts
+
+sonar.javascript.lcov.reportPaths=src/coverage/lcov.info
+
+# Encoding of the source code. Default is default system encoding
+sonar.sourceEncoding=UTF-8

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -14,3 +14,4 @@ sonar.javascript.lcov.reportPaths=src/coverage/lcov.info
 
 # Encoding of the source code. Default is default system encoding
 sonar.sourceEncoding=UTF-8
+

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -14,4 +14,3 @@ sonar.javascript.lcov.reportPaths=src/coverage/lcov.info
 
 # Encoding of the source code. Default is default system encoding
 sonar.sourceEncoding=UTF-8
-

--- a/src/package.json
+++ b/src/package.json
@@ -25,7 +25,7 @@
     "lodash": "^4.17.21"
   },
   "scripts": {
-    "unit": "./node_modules/.bin/jest --testPathPattern=tests/unit",
+    "unit": "./node_modules/.bin/jest --testPathPattern=tests/unit --coverage",
     "test:unit": "npm run compile && npm run unit",
     "lint:fix": "eslint --fix --output-file ./reports/eslint/report.html --format html -c .eslintrc.js --ext .ts .",
     "compile": "./node_modules/.bin/tsc",


### PR DESCRIPTION
Implement sonar scan properties and workflow to run sonar scan on the di-ipvreturn-api.
This includes the scan files, exclusions and code coverage.   

- [F2F-530](https://govukverify.atlassian.net/browse/F2F-530)


[F2F-530]: https://govukverify.atlassian.net/browse/F2F-530?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ