### PR TITLE
F2F-486: Add the IPR to CSLS processing

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -236,9 +236,9 @@ Resources:
 
   GovNotifyFunctionLogsSubscriptionFilterCSLS:
     Type: AWS::Logs::SubscriptionFilter
-    Condition: IsProdLikeEnvironment
+    #Condition: IsProdLikeEnvironment
     Properties:
-      DestinationArn: "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython"
+      DestinationArn: !FindInMap [ PlatformConfiguration, !Ref Environment, CSLSEGRESS ]
       FilterPattern: ""
       LogGroupName: !Ref GovNotifyFunctionLogGroup
 


### PR DESCRIPTION
Route the cloud watch logs to CSLS processing.  AWS Account id are configured on the CSLS.
Platform configuration is done for the ipvreturn-api.
Modified to allow all the environment to send logs. 

- [F2F-486](https://govukverify.atlassian.net/browse/F2F-486)


[F2F-486]: https://govukverify.atlassian.net/browse/F2F-486?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ