### PR TITLE
F2F-388: Setup Infrastructure and permissions to consumer TxMA events

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -60,8 +60,6 @@ Mappings:
   PlatformConfiguration:
     dev:
       CSLSEGRESS: arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython
-      TxMASQS: arn:aws:sqs:eu-west-2:178023842775:self-staging-EC-SQS-Output-Queue-return
-      TxMAKey: arn:aws:kms:eu-west-2:178023842775:key/aba0d7ef-779a-4f6c-9b50-ec91f6cb8b5c
     build:
       CSLSEGRESS: arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython
     staging:
@@ -732,9 +730,6 @@ Resources:
           MESSAGERETENTIONPERIODDAYS,
         ]
       VisibilityTimeout: 60
-      # KmsMasterKeyId: !Ref TxMAKeyAlias
-      # KmsMasterKeyAlias: "alias/aws/sqs"
-
 
   TxMASQSQueue:
     Type: AWS::SQS::Queue

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -151,7 +151,14 @@ Conditions:
           - "none"
   CreateProdResources: !Equals [ !Ref Environment, production]
   CreateNonProdResources: !Not [!Condition CreateProdResources]
-
+  IsMockedEnvironment: !Or
+    - Fn::Equals: 
+        - !Ref Environment
+        - dev
+    - Fn::Equals: 
+        - !Ref Environment
+        - build
+      
 Globals:
   Function:
     Runtime: nodejs18.x
@@ -350,7 +357,10 @@ Resources:
                 - "sqs:GetQueueAttributes"
                 - "sqs:ChangeMessageVisibility"
                 - "sqs:ReceiveMessage"
-              Resource: !FindInMap [PlatformConfiguration, !Ref Environment, TxMASQS]
+              Resource: !If
+                - IsMockedEnvironment
+                - !GetAtt MockTxMASQSQueue.Arn
+                - !FindInMap [PlatformConfiguration, !Ref Environment, TxMASQS]
 
     Metadata: # Manage esbuild properties
       BuildMethod: esbuild
@@ -392,7 +402,10 @@ Resources:
     Properties:
       BatchSize: 1
       Enabled: true
-      EventSourceArn: !FindInMap [PlatformConfiguration, !Ref Environment, TxMASQS]
+      EventSourceArn: !If
+        - IsMockedEnvironment
+        - !GetAtt MockTxMASQSQueue.Arn
+        - !FindInMap [PlatformConfiguration, !Ref Environment, TxMASQS]          
       FunctionName: !Ref PostEventFunction
 
   GovNotifyFunction:
@@ -707,6 +720,21 @@ Resources:
         - !Sub "alias/GovNotifyEncryptionKey-${AWS::StackName}"
         - alias/GovNotifyEncryptionKey
       TargetKeyId: !Ref GovNotifyEncryptionKey
+
+  MockTxMASQSQueue:
+    Type: AWS::SQS::Queue
+    Condition: IsMockedEnvironment
+    Properties:
+      MessageRetentionPeriod:
+        !FindInMap [
+          EnvironmentVariables,
+          !Ref Environment,
+          MESSAGERETENTIONPERIODDAYS,
+        ]
+      VisibilityTimeout: 60
+      # KmsMasterKeyId: !Ref TxMAKeyAlias
+      # KmsMasterKeyAlias: "alias/aws/sqs"
+
 
   TxMASQSQueue:
     Type: AWS::SQS::Queue

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -60,6 +60,8 @@ Mappings:
   PlatformConfiguration:
     dev:
       CSLSEGRESS: arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython
+      TxMASQS: arn:aws:sqs:eu-west-2:178023842775:self-staging-EC-SQS-Output-Queue-return
+      TxMAKey: arn:aws:kms:eu-west-2:178023842775:key/aba0d7ef-779a-4f6c-9b50-ec91f6cb8b5c
     build:
       CSLSEGRESS: arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython
     staging:
@@ -336,12 +338,12 @@ Resources:
               Fn::ImportValue:
                 !Sub "${L2DynamoStackName}-session-events-table-key-id"
         - Statement:
-            - Sid: TxMAKMS_Decryptkeys_Policy
+            - Sid: TxMAKMSDecryptkeysPolicy
               Effect: Allow
               Action:
                 - "kms:Decrypt"
               Resource: !FindInMap [PlatformConfiguration, !Ref Environment, TxMAKey]
-            - Sid: TxMASQS_ConsumeEvent_Policy
+            - Sid: TxMASQSConsumeEventPolicy
               Effect: Allow
               Action:
                 - "sqs:DeleteMessage"
@@ -349,15 +351,6 @@ Resources:
                 - "sqs:ChangeMessageVisibility"
                 - "sqs:ReceiveMessage"
               Resource: !FindInMap [PlatformConfiguration, !Ref Environment, TxMASQS]
-      Events:
-        SQSEvent:
-          Type: SQS
-          Properties:
-            Queue: !FindInMap [PlatformConfiguration, !Ref Environment, TxMASQS]
-            BatchSize: 1
-            Enabled: true
-            FunctionResponseTypes:
-              - ReportBatchItemFailures
 
     Metadata: # Manage esbuild properties
       BuildMethod: esbuild
@@ -393,6 +386,14 @@ Resources:
       Action: lambda:InvokeFunction
       FunctionName: !Ref PostEventFunction
       Principal: apigateway.amazonaws.com
+
+  PostEventFunctionSourceMapping:
+    Type: AWS::Lambda::EventSourceMapping
+    Properties:
+      BatchSize: 1
+      Enabled: true
+      EventSourceArn: !FindInMap [PlatformConfiguration, !Ref Environment, TxMASQS]
+      FunctionName: !Ref PostEventFunction
 
   GovNotifyFunction:
     Type: AWS::Serverless::Function

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -64,10 +64,16 @@ Mappings:
       CSLSEGRESS: arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython
     staging:
       CSLSEGRESS: arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython
+      TxMASQS: arn:aws:sqs:eu-west-2:178023842775:self-staging-EC-SQS-Output-Queue-return
+      TxMAKey: arn:aws:kms:eu-west-2:178023842775:key/aba0d7ef-779a-4f6c-9b50-ec91f6cb8b5c
     integration:
       CSLSEGRESS: arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython
+      TxMASQS: arn:aws:sqs:eu-west-2:729485541398:self-integration-EC-SQS-Output-Queue-return
+      TxMAKey: arn:aws:kms:eu-west-2:729485541398:key/e45c19b4-bf7c-4542-95d0-89485c20533c
     production:
       CSLSEGRESS: arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython
+      TxMASQS: arn:aws:sqs:eu-west-2:451773080033:self-production-EC-SQS-Output-Queue-return
+      TxMAKey: arn:aws:kms:eu-west-2:451773080033:key/35e96311-91fd-425e-bb53-b90bc8c3549c
 
   EnvironmentVariables: # This is all the environment specific environment variables that don't belong in globals.
     dev:
@@ -329,6 +335,29 @@ Resources:
             KeyId:
               Fn::ImportValue:
                 !Sub "${L2DynamoStackName}-session-events-table-key-id"
+        - Statement:
+            - Sid: TxMAKMS_Decryptkeys_Policy
+              Effect: Allow
+              Action:
+                - "kms:Decrypt"
+              Resource: !FindInMap [PlatformConfiguration, !Ref Environment, TxMAKey]
+            - Sid: TxMASQS_ConsumeEvent_Policy
+              Effect: Allow
+              Action:
+                - "sqs:DeleteMessage"
+                - "sqs:GetQueueAttributes"
+                - "sqs:ChangeMessageVisibility"
+                - "sqs:ReceiveMessage"
+              Resource: !FindInMap [PlatformConfiguration, !Ref Environment, TxMASQS]
+      Events:
+        SQSEvent:
+          Type: SQS
+          Properties:
+            Queue: !FindInMap [PlatformConfiguration, !Ref Environment, TxMASQS]
+            BatchSize: 1
+            Enabled: true
+            FunctionResponseTypes:
+              - ReportBatchItemFailures
 
     Metadata: # Manage esbuild properties
       BuildMethod: esbuild


### PR DESCRIPTION
IPVreturn services offer service to produce and consume events. To consume events, provide necessary permissions to lambda function to access the TxMA SQS queue and receive event. 
Added policies to receive event from TxMA queue to allow post event function to receive message.
Subscribe TxMA SQS to receive message form the cross account queue
 
- [F2F-388](https://govukverify.atlassian.net/browse/F2F-388)


[F2F-388]: https://govukverify.atlassian.net/browse/F2F-388?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ