### PR TITLE
[F2F-389]-Adding PermissionsBoundary to fix pipeline failure.

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -209,6 +209,10 @@ Resources:
       ThumbprintList:
         - !Sub "{{resolve:ssm:/${Environment}/ipvreturn/OIDC_THUMBPRINT}}"
       Url: !FindInMap [ EnvironmentVariables, !Ref Environment, OIDCURL ]
+    PermissionsBoundary: !If
+      - UsePermissionsBoundary
+      - !Ref PermissionsBoundary
+      - !Ref AWS::NoValue
 
   ### AssumeRoleWithWebIdentityRole
   AssumeRoleWithWebIdentityRole:


### PR DESCRIPTION
Adding PermissionsBoundary to be able to create OIDCProvider resource through pipeline