### PR TITLE
[F2F-715]-getSessionEventLambda | Replacing AssumeRoleWithWebIdentity call and using GetItem directly

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -200,50 +200,50 @@ Resources:
       VpcId:
         Fn::ImportValue: !Sub "${VpcStackName}-VpcId"
 
-  ### OIDC Provider as IAM entity
-  OIDCProvider:
-    Type: AWS::IAM::OIDCProvider
-    Properties:
-      ClientIdList:
-        - !Sub "{{resolve:ssm:/${Environment}/ipvreturn/CLIENT_ID}}"
-      ThumbprintList:
-        - !Sub "{{resolve:ssm:/${Environment}/ipvreturn/OIDC_THUMBPRINT}}"
-      Url: !FindInMap [ EnvironmentVariables, !Ref Environment, OIDCURL ]
-      PermissionsBoundary: !If
-        - UsePermissionsBoundary
-        - !Ref PermissionsBoundary
-        - !Ref AWS::NoValue
-
-  ### AssumeRoleWithWebIdentityRole
-  AssumeRoleWithWebIdentityRole:
-    Type: "AWS::IAM::Role"
-    Properties:
-      AssumeRolePolicyDocument:
-        Statement:
-          - Action: "sts:AssumeRoleWithWebIdentity"
-            Effect: Allow
-            Principal:
-              Federated: !GetAtt OIDCProvider.Arn
-        Version: 2012-10-17
-      Policies:
-        - PolicyName: GetSessionEventPolicy
-          PolicyDocument:
-            Version: '2012-10-17'
-            Statement:
-              - Effect: Allow
-                Action:
-                  - "dynamodb:GetItem"
-                Resource:
-                  Fn::ImportValue: !Sub "${L2DynamoStackName}-session-events-table-arn"
-              - Effect: Allow
-                Action:
-                  - "kms:Decrypt"
-                Resource:
-                  Fn::ImportValue: !Sub "${L2DynamoStackName}-session-events-table-key-arn"
-      PermissionsBoundary: !If
-        - UsePermissionsBoundary
-        - !Ref PermissionsBoundary
-        - !Ref AWS::NoValue
+#  ### OIDC Provider as IAM entity
+#  OIDCProvider:
+#    Type: AWS::IAM::OIDCProvider
+#    Properties:
+#      ClientIdList:
+#        - !Sub "{{resolve:ssm:/${Environment}/ipvreturn/CLIENT_ID}}"
+#      ThumbprintList:
+#        - !Sub "{{resolve:ssm:/${Environment}/ipvreturn/OIDC_THUMBPRINT}}"
+#      Url: !FindInMap [ EnvironmentVariables, !Ref Environment, OIDCURL ]
+#      PermissionsBoundary: !If
+#        - UsePermissionsBoundary
+#        - !Ref PermissionsBoundary
+#        - !Ref AWS::NoValue
+#
+#  ### AssumeRoleWithWebIdentityRole
+#  AssumeRoleWithWebIdentityRole:
+#    Type: "AWS::IAM::Role"
+#    Properties:
+#      AssumeRolePolicyDocument:
+#        Statement:
+#          - Action: "sts:AssumeRoleWithWebIdentity"
+#            Effect: Allow
+#            Principal:
+#              Federated: !GetAtt OIDCProvider.Arn
+#        Version: 2012-10-17
+#      Policies:
+#        - PolicyName: GetSessionEventPolicy
+#          PolicyDocument:
+#            Version: '2012-10-17'
+#            Statement:
+#              - Effect: Allow
+#                Action:
+#                  - "dynamodb:GetItem"
+#                Resource:
+#                  Fn::ImportValue: !Sub "${L2DynamoStackName}-session-events-table-arn"
+#              - Effect: Allow
+#                Action:
+#                  - "kms:Decrypt"
+#                Resource:
+#                  Fn::ImportValue: !Sub "${L2DynamoStackName}-session-events-table-key-arn"
+#      PermissionsBoundary: !If
+#        - UsePermissionsBoundary
+#        - !Ref PermissionsBoundary
+#        - !Ref AWS::NoValue
 
   ### Start of API Gateway definition.
   IPVRRestApi:
@@ -610,10 +610,17 @@ Resources:
           CLIENT_ID_SSM_PATH: !Sub "/${Environment}/ipvreturn/CLIENT_ID"
           OIDC_URL: !FindInMap [ EnvironmentVariables, !Ref Environment, OIDCURL ]
           RETURN_REDIRECT_URL: !FindInMap [ EnvironmentVariables, !Ref Environment, RETURNREDIRECTURL ]
-          ASSUMEROLE_WITH_WEB_IDENTITY_ARN: !GetAtt AssumeRoleWithWebIdentityRole.Arn
+          #ASSUMEROLE_WITH_WEB_IDENTITY_ARN: !GetAtt AssumeRoleWithWebIdentityRole.Arn
           TXMA_QUEUE_URL: !Ref TxMASQSQueue
       Policies:
         - AWSLambdaBasicExecutionRole
+        - DynamoDBReadPolicy: # Added temporarily, needs to be reverted once the OIDCProvider changes are in
+            TableName:
+              Fn::ImportValue:
+                !Sub "${L2DynamoStackName}-session-events-table-name"
+        - KMSDecryptPolicy: # Added temporarily, needs to be reverted once the OIDCProvider changes are in
+            KeyId:
+              Fn::ImportValue: !Sub "${L2DynamoStackName}-session-events-table-key-id"
         - SSMParameterReadPolicy:
             ParameterName: !Sub "${Environment}/ipvreturn/CLIENT_ID"
         - Statement:

--- a/src/services/EnvironmentVariables.ts
+++ b/src/services/EnvironmentVariables.ts
@@ -37,6 +37,8 @@ export class EnvironmentVariables {
 
 	private readonly CLIENT_ID_SSM_PATH = process.env.CLIENT_ID_SSM_PATH;
 
+	private USE_ASSUMEROLE_WITH_WEB_IDENTITY = process.env.USE_ASSUMEROLE_WITH_WEB_IDENTITY;
+
 	/*
 	 * This function performs validation on env variable values.
 	 * If certain variables have unexpected values the constructor will throw an error and/or log an error message
@@ -87,14 +89,18 @@ export class EnvironmentVariables {
 					!this.KMS_KEY_ARN || this.KMS_KEY_ARN.trim().length === 0 ||
 					!this.SESSION_EVENTS_TABLE || this.SESSION_EVENTS_TABLE.trim().length === 0 ||
 					!this.OIDC_URL || this.OIDC_URL.trim().length === 0 ||
-					!this.RETURN_REDIRECT_URL || this.RETURN_REDIRECT_URL.trim().length === 0 ||
-					!this.ASSUMEROLE_WITH_WEB_IDENTITY_ARN || this.ASSUMEROLE_WITH_WEB_IDENTITY_ARN.trim().length === 0) {
+					!this.RETURN_REDIRECT_URL || this.RETURN_REDIRECT_URL.trim().length === 0) {
+					//!this.ASSUMEROLE_WITH_WEB_IDENTITY_ARN || this.ASSUMEROLE_WITH_WEB_IDENTITY_ARN.trim().length === 0) {
 					logger.error(`Get Session event data Service - Misconfigured external API's key ${EnvironmentVariables.name}`);
 					throw new AppError(HttpCodesEnum.SERVER_ERROR, Constants.ENV_VAR_UNDEFINED);
 				}
 				if (!this.OIDC_JWT_ASSERTION_TOKEN_EXP || this.OIDC_JWT_ASSERTION_TOKEN_EXP.trim().length === 0) {
 					this.OIDC_JWT_ASSERTION_TOKEN_EXP = "300";
 					logger.warn("OIDC_JWT_ASSERTION_TOKEN_EXP env var is not set. Setting the expiry to default - 5 minutes.");
+				}
+				if (!this.USE_ASSUMEROLE_WITH_WEB_IDENTITY || this.USE_ASSUMEROLE_WITH_WEB_IDENTITY.trim().length === 0) {
+					this.USE_ASSUMEROLE_WITH_WEB_IDENTITY = "false";
+					logger.warn("USE_ASSUMEROLE_WITH_WEB_IDENTITY env var is not set. Setting the value to default - False.");
 				}
 				break;
 			}
@@ -176,5 +182,9 @@ export class EnvironmentVariables {
 
 	oidcJwtAssertionTokenExpiry(): any {
 		return this.OIDC_JWT_ASSERTION_TOKEN_EXP;
+	}
+
+	userAssumeRoleWithWebIdentity(): boolean {
+		return JSON.parse(this.USE_ASSUMEROLE_WITH_WEB_IDENTITY!);
 	}
 }


### PR DESCRIPTION
Adding a config switch in the code to temporarily skip the AussumeRoleWithWebIdentiy and use GetItem directly to fetch the sessionEvent data.

After deploying these changes to backend-main-richa-1 BE stack the FE is now restored and able to redirect the user to the return journey url as expected. PFB the screenshot as evidence.

<img width="1121" alt="Screenshot 2023-06-01 at 21 04 21" src="https://github.com/alphagov/di-ipvreturn-api/assets/115095929/b34a9df0-be5f-445f-b046-9412956d3f3d">


Please Note: Once the main stack is deployed successfully with these changes, we may have to update the FE stack to point to the BE main stack instead of backend-main-richa-1 stack.