### PR TITLE
F2F-388: Fix for MockTxMASQS conditional Error

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -60,8 +60,12 @@ Mappings:
   PlatformConfiguration:
     dev:
       CSLSEGRESS: arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython
+      TxMASQS: "mock-sqs"
+      TxMAKey: "mock-kms"
     build:
       CSLSEGRESS: arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython
+      TxMASQS: "mock-sqs"
+      TxMAKey: "mock-kms"
     staging:
       CSLSEGRESS: arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython
       TxMASQS: arn:aws:sqs:eu-west-2:178023842775:self-staging-EC-SQS-Output-Queue-return
@@ -114,6 +118,7 @@ Mappings:
       RETURNJOURNEYURL: "https://return.account.gov.uk"
       SESSIONRETURNRECORDTTL: 950400 # Default 11 days
       DNSSUFFIX: "return.account.gov.uk"
+      OIDCURL: "https://oidc.account.gov.uk/"
       RETURNREDIRECTURL: "https://return.account.gov.uk/callback"
   TxMAAccounts:
     # EVENTS is used to egress to TxMA.
@@ -410,12 +415,15 @@ Resources:
             KeyId:
               Fn::ImportValue:
                 !Sub "${L2DynamoStackName}-session-events-table-key-id"
-        - Statement:
+        - Statement: 
             - Sid: TxMAKMSDecryptkeysPolicy
               Effect: Allow
               Action:
                 - "kms:Decrypt"
-              Resource: !FindInMap [PlatformConfiguration, !Ref Environment, TxMAKey]
+              Resource: !If
+                - IsMockedEnvironment
+                - !GetAtt MockTxMASQSQueue.Arn
+                - !FindInMap [PlatformConfiguration, !Ref Environment, TxMAKey]   
             - Sid: TxMASQSConsumeEventPolicy
               Effect: Allow
               Action:
@@ -426,7 +434,7 @@ Resources:
               Resource: !If
                 - IsMockedEnvironment
                 - !GetAtt MockTxMASQSQueue.Arn
-                - !FindInMap [PlatformConfiguration, !Ref Environment, TxMASQS]
+                - !FindInMap [PlatformConfiguration, !Ref Environment, TxMASQS]   
 
     Metadata: # Manage esbuild properties
       BuildMethod: esbuild


### PR DESCRIPTION
### What changed

- Template was trying to fetch a TxMAKey in dev and build for which a mapping value didn't exist. Amended the existing conditional to avoid this error (the actual key value is not used in dev and build)
- added OIDCUrl for prod to mappings


### Issue tracking


- [F2F-388](https://govukverify.atlassian.net/browse/F2F-388)
- [F2F-726](https://govukverify.atlassian.net/browse/F2F-726)


[F2F-388]: https://govukverify.atlassian.net/browse/F2F-388?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[F2F-726]: https://govukverify.atlassian.net/browse/F2F-726?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ