### PR TITLE
F2F-726: Removed permissions boundary from oidc

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -230,10 +230,6 @@ Resources:
       ThumbprintList:
         - !Sub "{{resolve:ssm:/${Environment}/ipvreturn/OIDC_THUMBPRINT}}"
       Url: !FindInMap [ EnvironmentVariables, !Ref Environment, OIDCURL ]
-      PermissionsBoundary: !If
-        - UsePermissionsBoundary
-        - !Ref PermissionsBoundary
-        - !Ref AWS::NoValue
 
   ### AssumeRoleWithWebIdentityRole
   AssumeRoleWithWebIdentityRole:


### PR DESCRIPTION
### What changed

Removed permissions boundary from OIDC

### Why did it change

![image](https://github.com/alphagov/di-ipvreturn-api/assets/110675931/869a1c66-8e7a-4732-a881-e05a88247082)

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [F2F-726](https://govukverify.atlassian.net/browse/F2F-726)

## Checklists

### PII logging

- [ ] Verified that no PII data is being logged

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[F2F-726]: https://govukverify.atlassian.net/browse/F2F-726?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ