### PR TITLE
F2F-870 API Test Harness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@ bin-release/
 # Project files, i.e. `.project`, `.actionScriptProperties` and `.flexProperties`
 # should NOT be excluded as they contain compiler settings and other important
 # information for Eclipse / Flash Builder.
+
+/.env
+/docker_vars.env

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ bin-release/
 
 /.env
 /docker_vars.env
+results/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+FROM ubuntu:latest
+
+RUN apt update -y && apt upgrade -y
+RUN apt install -y curl unzip
+
+RUN curl -sL https://deb.nodesource.com/setup_18.x | bash -
+RUN apt install -y nodejs
+
+RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
+RUN unzip awscliv2.zip
+RUN ./aws/install
+
+COPY . /
+WORKDIR /
+RUN chmod +x run-tests.sh
+
+RUN cd /src && npm ci
+
+ENTRYPOINT ["/run-tests.sh"]

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -333,16 +333,10 @@ Resources:
   IPVRApiCustomDomain:
     Type: AWS::ApiGateway::DomainName
     Properties:
-      DomainName: !If
-        - CreateDevResources
-        - !Sub
-          - "api-${AWS::StackName}.${DNSSUFFIX}"
-          - DNSSUFFIX:
-              !FindInMap [ EnvironmentVariables, !Ref Environment, DNSSUFFIX ]
-        - !Sub
-          - "api.${DNSSUFFIX}"
-          - DNSSUFFIX:
-              !FindInMap [ EnvironmentVariables, !Ref Environment, DNSSUFFIX ]
+      DomainName: !Sub
+        - "api.${DNSSUFFIX}"
+        - DNSSUFFIX:
+            !FindInMap [ EnvironmentVariables, !Ref Environment, DNSSUFFIX ]
       EndpointConfiguration:
         Types:
           - REGIONAL
@@ -352,7 +346,10 @@ Resources:
   IPVRApiCertificateRecord:
     Type: AWS::Route53::RecordSet
     Properties:
-      Name: !Ref IPVRApiCustomDomain
+      Name: !Sub
+        - "api.${DNSSUFFIX}"
+        - DNSSUFFIX:
+            !FindInMap [ EnvironmentVariables, !Ref Environment, DNSSUFFIX ]
       Type: A
       HostedZoneId: !Sub "{{resolve:ssm:/${Environment}/Platform/Route53/PrimaryZoneID}}"
       AliasTarget:
@@ -363,7 +360,10 @@ Resources:
     Type: AWS::ApiGateway::BasePathMapping
     DependsOn: IPVRApiCustomDomain
     Properties:
-      DomainName: !Ref IPVRApiCustomDomain
+      DomainName: !Sub
+        - "api.${DNSSUFFIX}"
+        - DNSSUFFIX:
+            !FindInMap [ EnvironmentVariables, !Ref Environment, DNSSUFFIX ]
       RestApiId: !Ref IPVRRestApi
       Stage: !Sub "${IPVRRestApi.Stage}"
 

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -234,7 +234,7 @@ Resources:
         - !Sub "{{resolve:ssm:/${Environment}/ipvreturn/CLIENT_ID}}"
       ThumbprintList:
         - !Sub "{{resolve:ssm:/${Environment}/ipvreturn/OIDC_THUMBPRINT}}"
-      Url: !FindInMap [ EnvironmentVariables, !Ref Environment, OIDCURL ]
+      Url: "https://oidc.ddunford.staging.account.gov.uk/"
 
   ### AssumeRoleWithWebIdentityRole
   AssumeRoleWithWebIdentityRole:
@@ -333,7 +333,13 @@ Resources:
   IPVRApiCustomDomain:
     Type: AWS::ApiGateway::DomainName
     Properties:
-      DomainName: !Sub
+      DomainName: !If
+        - CreateDevResources
+        - !Sub
+          - "api-${AWS::StackName}.${DNSSUFFIX}"
+          - DNSSUFFIX:
+              !FindInMap [ EnvironmentVariables, !Ref Environment, DNSSUFFIX ]
+        - !Sub
           - "api.${DNSSUFFIX}"
           - DNSSUFFIX:
               !FindInMap [ EnvironmentVariables, !Ref Environment, DNSSUFFIX ]
@@ -346,10 +352,7 @@ Resources:
   IPVRApiCertificateRecord:
     Type: AWS::Route53::RecordSet
     Properties:
-      Name: !Sub
-          - "api.${DNSSUFFIX}"
-          - DNSSUFFIX:
-              !FindInMap [ EnvironmentVariables, !Ref Environment, DNSSUFFIX ]
+      Name: !Ref IPVRApiCustomDomain
       Type: A
       HostedZoneId: !Sub "{{resolve:ssm:/${Environment}/Platform/Route53/PrimaryZoneID}}"
       AliasTarget:
@@ -360,10 +363,7 @@ Resources:
     Type: AWS::ApiGateway::BasePathMapping
     DependsOn: IPVRApiCustomDomain
     Properties:
-      DomainName: !Sub
-          - "api.${DNSSUFFIX}"
-          - DNSSUFFIX:
-              !FindInMap [ EnvironmentVariables, !Ref Environment, DNSSUFFIX ]
+      DomainName: !Ref IPVRApiCustomDomain
       RestApiId: !Ref IPVRRestApi
       Stage: !Sub "${IPVRRestApi.Stage}"
 

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -234,7 +234,7 @@ Resources:
         - !Sub "{{resolve:ssm:/${Environment}/ipvreturn/CLIENT_ID}}"
       ThumbprintList:
         - !Sub "{{resolve:ssm:/${Environment}/ipvreturn/OIDC_THUMBPRINT}}"
-      Url: "https://oidc.ddunford.staging.account.gov.uk/"
+      Url: !FindInMap [ EnvironmentVariables, !Ref Environment, OIDCURL ]
 
   ### AssumeRoleWithWebIdentityRole
   AssumeRoleWithWebIdentityRole:
@@ -898,3 +898,14 @@ Resources:
         - !Sub "alias/TxMAKMSEncryptionKey-${AWS::StackName}"
         - alias/TxMAKMSEncryptionKey
       TargetKeyId: !Ref TxMAKMSEncryptionKey
+
+Outputs:
+  MockTxMASQSQueueUrl:
+    Description: "SQS TXMA Consumer Queue URL"
+    Value: !Ref MockTxMASQSQueue
+    Condition: IsMockedEnvironment
+
+  SessionEventsTable:
+    Description: "SessionEvents Table Name"
+    Value:
+      Fn::ImportValue: !Sub "${L2DynamoStackName}-session-events-table-name"

--- a/run-tests-locally.sh
+++ b/run-tests-locally.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+set -eu
+
+if [ $# -ge 1 ] && [ -n "$1" ]
+then
+    echo "Running test container against $1"
+
+    export SAM_STACK=$1 
+    export AWS_REGION="eu-west-2"
+    export TEST_REPORT_DIR="results"
+    export ENVIRONMENT="dev"
+    export DockerImageName="$SAM_STACK"_testcontainerimage
+
+    mkdir -p results # The directory on the host where the test results will be outputted.
+
+    aws cloudformation describe-stacks --stack-name "$SAM_STACK" --region "$AWS_REGION" --query 'Stacks[0].Outputs[].{key: OutputKey, value: OutputValue}' --output text > cf-output.txt
+    eval $(awk '{ printf("export CFN_%s=\"%s\"\n", $1, $2) }' cf-output.txt)
+    awk '{ printf("CFN_%s=\"%s\"\n", $1, $2) }' cf-output.txt > docker_vars.env
+    echo TEST_REPORT_DIR="$TEST_REPORT_DIR" >> docker_vars.env
+    echo TEST_REPORT_ABSOLUTE_DIR="$TEST_REPORT_DIR" >> docker_vars.env
+    echo TEST_ENVIRONMENT="$ENVIRONMENT" >> docker_vars.env
+    echo ENVIRONMENT="$ENVIRONMENT" >> docker_vars.env
+    echo SAM_STACK_NAME="$SAM_STACK" >> docker_vars.env
+    echo AWS_ACCESS_KEY_ID="$AWS_ACCESS_KEY_ID" >> docker_vars.env
+    echo AWS_SECRET_ACCESS_KEY="$AWS_SECRET_ACCESS_KEY" >> docker_vars.env
+    echo AWS_SESSION_TOKEN="$AWS_SESSION_TOKEN" >> docker_vars.env
+
+    #clean existing container and image before creating a new one
+    echo "Removing existing containers and images for the test"
+    docker ps -a --filter "ancestor=$DockerImageName" --filter "status=exited" -q | xargs docker rm
+    docker images $DockerImageName -q |xargs docker rmi
+
+    docker build -f Dockerfile -t $DockerImageName .
+    docker run --env-file docker_vars.env -v $(pwd)/results:/results $DockerImageName
+else    
+    echo "Please ensure you've got a stack name as the first argument after ./run_tests_locally.sh..."
+    echo "E.g. ./run_tests_locally.sh cri-cic-api"
+fi

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -9,10 +9,9 @@ remove_quotes () {
 declare error_code
 # shellcheck disable=SC2154
 #The CFN variables seem to include quotes when used in tests these must be removed before assigning them.
-CFN_MockTxMASQSQueueUrl_NoQuotes=$(remove_quotes "$CFN_MockTxMASQSQueueUrl")
-CFN_SessionEventsTable_NoQuotes=$(remove_quotes "$CFN_SessionEventsTable")
-
 export API_TEST_SESSION_EVENTS_TABLE=$(remove_quotes $CFN_SessionEventsTable)
+# shellcheck disable=SC2154
+#The CFN variables seem to include quotes when used in tests these must be removed before assigning them.
 export API_TEST_SQS_TXMA_CONSUMER_QUEUE=$(remove_quotes $CFN_MockTxMASQSQueueUrl)
 
 cd ./src; npm run test:api

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -14,7 +14,7 @@ export API_TEST_SESSION_EVENTS_TABLE=$(remove_quotes $CFN_SessionEventsTable)
 #The CFN variables seem to include quotes when used in tests these must be removed before assigning them.
 export API_TEST_SQS_TXMA_CONSUMER_QUEUE=$(remove_quotes $CFN_MockTxMASQSQueueUrl)
 
-cd ./src; npm run test:api
+cd /src; npm run test:api
 error_code=$?
 
 cp -rf results $TEST_REPORT_ABSOLUTE_DIR

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -17,8 +17,6 @@ export API_TEST_SQS_TXMA_CONSUMER_QUEUE=$(remove_quotes $CFN_MockTxMASQSQueueUrl
 cd ./src; npm run test:api
 error_code=$?
 
-pwd
-ls
 cp -rf results $TEST_REPORT_ABSOLUTE_DIR
 
 exit $error_code

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+set -eu
+
+remove_quotes () {
+  echo "$1" | tr -d '"'
+}
+
+declare error_code
+# shellcheck disable=SC2154
+#The CFN variables seem to include quotes when used in tests these must be removed before assigning them.
+CFN_MockTxMASQSQueueUrl_NoQuotes=$(remove_quotes "$CFN_MockTxMASQSQueueUrl")
+CFN_SessionEventsTable_NoQuotes=$(remove_quotes "$CFN_SessionEventsTable")
+
+export API_TEST_SESSION_EVENTS_TABLE=$(remove_quotes $CFN_SessionEventsTable)
+export API_TEST_SQS_TXMA_CONSUMER_QUEUE=$(remove_quotes $CFN_MockTxMASQSQueueUrl)
+
+cd ./src; npm run test:api
+error_code=$?
+
+cp -rf results $TEST_REPORT_ABSOLUTE_DIR
+
+exit $error_code

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -17,6 +17,8 @@ export API_TEST_SQS_TXMA_CONSUMER_QUEUE=$(remove_quotes $CFN_MockTxMASQSQueueUrl
 cd ./src; npm run test:api
 error_code=$?
 
+pwd
+ls
 cp -rf results $TEST_REPORT_ABSOLUTE_DIR
 
 exit $error_code

--- a/src/.gitignore
+++ b/src/.gitignore
@@ -5,3 +5,4 @@ dist/
 reports/
 build/
 .DS_Store
+.env

--- a/src/README.md
+++ b/src/README.md
@@ -12,6 +12,8 @@ To run all unit tests, run `npm run test:unit`. This will compile and run all th
 
 To run the infra tests, run `npm run test:infra`.
 
+To run the API tests, run `npm run test:api`. Note that these tests need to inject items on to the Mock TXMA consumer queue directly hence need to be run in an environment which has active AWS credentials.
+
 ### How to perform lint checks an individual test file
 
 To check if there are any linting issues, run `npm lint`. If there are any critical errors, this command 

--- a/src/README.md
+++ b/src/README.md
@@ -8,11 +8,24 @@ From `src` folder run `sam build`
 
 ## How to run tests
 
+### Unit tests
+
 To run all unit tests, run `npm run test:unit`. This will compile and run all the unit tests in the `/tests` directory.
+
+### Infra tests
 
 To run the infra tests, run `npm run test:infra`.
 
+### API tests
+
 To run the API tests, run `npm run test:api`. Note that these tests need to inject items on to the Mock TXMA consumer queue directly hence need to be run in an environment which has active AWS credentials.
+
+The API tests also require the following env vars to be set:
+
+- `API_TEST_SESSION_EVENTS_TABLE` - table name for the Session Events table to check
+- `API_TEST_SQS_TXMA_CONSUMER_QUEUE` - URL of the TXMA mock consumer queue
+
+These are set automatically by `./run-tests-locally.sh <AWS_Stack_Name>`.
 
 ### How to perform lint checks an individual test file
 

--- a/src/jest.config.ts
+++ b/src/jest.config.ts
@@ -26,5 +26,9 @@ export default {
     '!./tests/**/*.ts',
     '!./jest.config.ts'
   ],
-  testEnvironment: 'node'
+  testEnvironment: 'node',
+  reporters: [
+    'default',
+    ['jest-junit', { outputDirectory: 'results', outputName: 'report.xml' }]
+  ]
 }

--- a/src/jest.config.ts
+++ b/src/jest.config.ts
@@ -20,5 +20,11 @@ export default {
   setupFiles: [
     './jest.setup.ts'
   ],
+  collectCoverageFrom: [
+    './**/*.ts',
+    '!./**/tests/**/*.ts',
+    '!./tests/**/*.ts',
+    '!./jest.config.ts'
+  ],
   testEnvironment: 'node'
 }

--- a/src/models/ReturnSQSEvent.ts
+++ b/src/models/ReturnSQSEvent.ts
@@ -5,7 +5,8 @@ export type EventType = "AUTH_IPV_AUTHORISATION_REQUESTED" | "F2F_YOTI_START" | 
 export interface ReturnSQSEvent {
 	event_id: string;
 	client_id: string;
-	clientLandingPageUrl: string;
+	clientLandingPageUrl?: string;
+	component_id?: string;
 	event_name: EventType;
 	timestamp: number;
 	timestamp_formatted: string;

--- a/src/models/ReturnSQSEvent.ts
+++ b/src/models/ReturnSQSEvent.ts
@@ -6,7 +6,6 @@ export interface ReturnSQSEvent {
 	event_id: string;
 	client_id: string;
 	clientLandingPageUrl?: string;
-	component_id?: string;
 	event_name: EventType;
 	timestamp: number;
 	timestamp_formatted: string;

--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -48,6 +48,7 @@
         "eslint-plugin-prettier": "^4.2.1",
         "eslint-plugin-security": "^1.6.0",
         "jest": "^29.4.1",
+        "jest-junit": "^16.0.0",
         "jest-mock-extended": "^3.0.1",
         "prettier": "^2.8.4",
         "ts-jest": "^29.0.5",
@@ -6649,6 +6650,33 @@
         "fsevents": "^2.3.2"
       }
     },
+    "node_modules/jest-junit": {
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/jest-junit/-/jest-junit-16.0.0.tgz",
+      "integrity": "sha512-A94mmw6NfJab4Fg/BlvVOUXzXgF0XIH6EmTgJ5NDPp4xoKq0Kr7sErb+4Xs9nZvu58pJojz5RFGpqnZYJTrRfQ==",
+      "dev": true,
+      "dependencies": {
+        "mkdirp": "^1.0.4",
+        "strip-ansi": "^6.0.1",
+        "uuid": "^8.3.2",
+        "xml": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=10.12.0"
+      }
+    },
+    "node_modules/jest-junit/node_modules/mkdirp": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+      "dev": true,
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/jest-leak-detector": {
       "version": "29.5.0",
       "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-29.5.0.tgz",
@@ -9408,6 +9436,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/xml": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/xml/-/xml-1.0.1.tgz",
+      "integrity": "sha512-huCv9IH9Tcf95zuYCsQraZtWnJvBtLVE0QHMOs8bWyZAFZNDcYjsPq1nEx8jKA9y+Beo9v+7OBPRisQTjinQMw==",
+      "dev": true
     },
     "node_modules/y18n": {
       "version": "5.0.8",

--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -37,7 +37,7 @@
         "@types/node-jose": "^1.1.10",
         "@typescript-eslint/eslint-plugin": "^5.50.0",
         "@typescript-eslint/eslint-plugin-tslint": "^5.50.0",
-        "dotenv": "^16.0.3",
+        "dotenv": "^16.3.1",
         "eslint": "^8.32.0",
         "eslint-config-airbnb-typescript": "^17.0.0",
         "eslint-config-prettier": "^8.6.0",
@@ -4265,12 +4265,15 @@
       }
     },
     "node_modules/dotenv": {
-      "version": "16.0.3",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.3.tgz",
-      "integrity": "sha512-7GO6HghkA5fYG9TYnNxi14/7K9f5occMlp3zXAuSxn7CKCxt9xbNWG7yF8hTCSUchlfWSe3uLmlPfigevRItzQ==",
+      "version": "16.3.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.3.1.tgz",
+      "integrity": "sha512-IPzF4w4/Rd94bA9imS68tZBaYyBWSCE47V1RGuMrB94iyTOIEwRmVL2x/4An+6mETpLrKJ5hQkB8W4kFAadeIQ==",
       "dev": true,
       "engines": {
         "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/motdotla/dotenv?sponsor=1"
       }
     },
     "node_modules/ecdsa-sig-formatter": {

--- a/src/package.json
+++ b/src/package.json
@@ -56,6 +56,7 @@
     "eslint-plugin-prettier": "^4.2.1",
     "eslint-plugin-security": "^1.6.0",
     "jest": "^29.4.1",
+    "jest-junit": "^16.0.0",
     "jest-mock-extended": "^3.0.1",
     "prettier": "^2.8.4",
     "ts-jest": "^29.0.5",

--- a/src/package.json
+++ b/src/package.json
@@ -19,10 +19,10 @@
     "class-validator": "0.14.0",
     "ecdsa-sig-formatter": "^1.0.11",
     "esbuild": "0.14.14",
-    "node-jose": "^2.1.1",
     "jose": "^4.11.2",
-    "notifications-node-client": "^7.0.0",
-    "lodash": "^4.17.21"
+    "lodash": "^4.17.21",
+    "node-jose": "^2.1.1",
+    "notifications-node-client": "^7.0.0"
   },
   "scripts": {
     "unit": "./node_modules/.bin/jest --testPathPattern=tests/unit --coverage",
@@ -45,7 +45,7 @@
     "@types/node-jose": "^1.1.10",
     "@typescript-eslint/eslint-plugin": "^5.50.0",
     "@typescript-eslint/eslint-plugin-tslint": "^5.50.0",
-    "dotenv": "^16.0.3",
+    "dotenv": "^16.3.1",
     "eslint": "^8.32.0",
     "eslint-config-airbnb-typescript": "^17.0.0",
     "eslint-config-prettier": "^8.6.0",

--- a/src/tests/api/postEventStream.test.ts
+++ b/src/tests/api/postEventStream.test.ts
@@ -1,0 +1,82 @@
+import {
+  VALID_AUTH_IPV_AUTHORISATION_REQUESTED_TXMA_EVENT,
+  VALID_IPV_F2F_CRI_VC_CONSUMED_TXMA_EVENT,
+  VALID_F2F_YOTI_START_TXMA_EVENT,
+} from "../unit/data/sqs-events";
+import 'dotenv/config';
+import { randomUUID } from "crypto";
+import { getCompletedDynamoRecord, postMockEvent } from "./utils/ApiTestSteps";
+
+
+describe("post Events on to mock SQS queue", () => {
+
+  let user : string;
+
+  beforeAll(() => {
+    user = randomUUID();
+  });
+
+  it("should post an AUTH_IPV_AUTHORISATION_REQUESTED TxMA event", async () => {
+    const response = await postMockEvent(VALID_AUTH_IPV_AUTHORISATION_REQUESTED_TXMA_EVENT, user);
+    console.log(response);
+    expect(response.MessageId).toBeTruthy();
+  });
+
+  it("should post an VALID_IPV_F2F_CRI_VC_CONSUMED_TXMA_EVENT TxMA event", async () => {
+    const response = await postMockEvent(VALID_IPV_F2F_CRI_VC_CONSUMED_TXMA_EVENT, user);
+    console.log(response);
+    expect(response.MessageId).toBeTruthy();
+  });
+
+  it("should post an VALID_F2F_YOTI_START_TXMA_EVENT TxMA event", async () => {
+    const response = await postMockEvent(VALID_F2F_YOTI_START_TXMA_EVENT, user);
+    console.log(response);
+    expect(response.MessageId).toBeTruthy();
+  });
+
+  it("should eventually result in a Dynamo record with the details of all three events populated", async () => {
+    const response = await getCompletedDynamoRecord(user);
+    console.log(response);
+    expect(response.Item?.notified).toEqual({BOOL: true});
+    expect(response.Item?.nameParts).toEqual({
+      L: [
+        {
+          M: {
+            type: {
+              S: "GivenName",
+            },
+            value: {
+              S: "ANGELA",
+            },
+          },
+        },
+        {
+          M: {
+            type: {
+              S: "GivenName",
+            },
+            value: {
+              S: "ZOE",
+            },
+          },
+        },
+        {
+          M: {
+            type: {
+              S: "FamilyName",
+            },
+            value: {
+              S: "UK SPECIMEN",
+            },
+          },
+        },
+      ],
+    });
+    expect(response.Item?.clientName).toEqual({S: "ekwU"});
+    expect(response.Item?.redirectUri).toEqual({S: "REDIRECT_URL"});
+    expect(response.Item?.userEmail).toEqual({S: "jest@test.com"});
+  });
+
+
+
+});

--- a/src/tests/api/postEventStream.test.ts
+++ b/src/tests/api/postEventStream.test.ts
@@ -2,7 +2,7 @@ import {
   VALID_AUTH_IPV_AUTHORISATION_REQUESTED_TXMA_EVENT,
   VALID_IPV_F2F_CRI_VC_CONSUMED_TXMA_EVENT,
   VALID_F2F_YOTI_START_TXMA_EVENT,
-} from "../unit/data/sqs-events";
+} from "../data/sqs-events";
 import 'dotenv/config';
 import { randomUUID } from "crypto";
 import { getCompletedDynamoRecord, postMockEvent } from "./utils/ApiTestSteps";

--- a/src/tests/api/postEventStream.test.ts
+++ b/src/tests/api/postEventStream.test.ts
@@ -75,8 +75,6 @@ describe("post Events on to mock SQS queue", () => {
     expect(response.Item?.clientName).toEqual({S: "ekwU"});
     expect(response.Item?.redirectUri).toEqual({S: "REDIRECT_URL"});
     expect(response.Item?.userEmail).toEqual({S: "jest@test.com"});
-  });
-
-
+  }, 10000); // timeout set to 10s to avoid infinite loop
 
 });

--- a/src/tests/api/utils/ApiTestSteps.ts
+++ b/src/tests/api/utils/ApiTestSteps.ts
@@ -3,7 +3,7 @@ import { SendMessageCommand, SendMessageCommandOutput, SQSClient } from "@aws-sd
 import { ReturnSQSEvent } from "../../../models/ReturnSQSEvent";
 import { DynamoDBClient, GetItemCommand, GetItemCommandOutput } from "@aws-sdk/client-dynamodb";
 
-const MOCK_TXMA_SQS_URL = "https://sqs.eu-west-2.amazonaws.com/489145412748/backend-ddunford-ipvr-MockTxMASQSQueue-eya9dVlVYRRL";
+const MOCK_TXMA_SQS_URL = process.env['API_TEST_SQS_TXMA_CONSUMER_QUEUE'];
 const AWS_REGION = process.env['AWS_REGION'];
 const SESSION_EVENTS_TABLE = process.env['API_TEST_SESSION_EVENTS_TABLE'];
 

--- a/src/tests/api/utils/ApiTestSteps.ts
+++ b/src/tests/api/utils/ApiTestSteps.ts
@@ -1,0 +1,45 @@
+import { randomUUID } from "crypto";
+import { SendMessageCommand, SendMessageCommandOutput, SQSClient } from "@aws-sdk/client-sqs";
+import { ReturnSQSEvent } from "../../../models/ReturnSQSEvent";
+import { DynamoDBClient, GetItemCommand, GetItemCommandOutput } from "@aws-sdk/client-dynamodb";
+
+const MOCK_TXMA_SQS_URL = "https://sqs.eu-west-2.amazonaws.com/489145412748/backend-ddunford-ipvr-MockTxMASQSQueue-eya9dVlVYRRL";
+const AWS_REGION = process.env['AWS_REGION'];
+const SESSION_EVENTS_TABLE = process.env['API_TEST_SESSION_EVENTS_TABLE'];
+
+const sqsClient = new SQSClient({
+  region: AWS_REGION,
+});
+const dynamoClient = new DynamoDBClient({
+  region: AWS_REGION,
+})
+
+export async function postMockEvent(inputEvent: ReturnSQSEvent, user: string): Promise<SendMessageCommandOutput> {
+  const event = structuredClone(inputEvent);
+  event.event_id = randomUUID();
+  event.user.user_id = user;
+  const timestamp = new Date();
+  timestamp.setMilliseconds(0);
+  event.timestamp = timestamp.getTime() / 1000;
+  event.timestamp_formatted = timestamp.toISOString();
+  const command = new SendMessageCommand({
+    QueueUrl: MOCK_TXMA_SQS_URL,
+    MessageBody: JSON.stringify(event),
+  });
+  return sqsClient.send(command);
+}
+
+export async function getCompletedDynamoRecord(user: string): Promise<GetItemCommandOutput> {
+  const command = new GetItemCommand({
+    Key: {
+      userId: {"S": user},
+    },
+    TableName: SESSION_EVENTS_TABLE,
+  });
+  console.log(command)
+  let response: GetItemCommandOutput;
+  do {
+    response = await dynamoClient.send(command);
+  } while (!(response.Item?.notified && response.Item.notified.BOOL));
+  return response;
+}

--- a/src/tests/data/sqs-events.ts
+++ b/src/tests/data/sqs-events.ts
@@ -1,4 +1,4 @@
-import {EventType, ReturnSQSEvent} from "../../../models/ReturnSQSEvent";
+import { ReturnSQSEvent } from "../../models/ReturnSQSEvent";
 
 export const VALID_GOV_NOTIFY_HANDLER_SQS_EVENT = {
   "Records": [

--- a/src/tests/data/sqs-events.ts
+++ b/src/tests/data/sqs-events.ts
@@ -86,6 +86,7 @@ export const VALID_IPV_F2F_CRI_VC_CONSUMED_TXMA_EVENT: ReturnSQSEvent = {
   "timestamp_formatted": "2023-04-19T11:00:01.000Z",
   "user": {
     "user_id": "01333e01-dde3-412f-a484-4444",
+    // pragma: allowlist nextline secret
     "email": "e914e32172adcdad6c0906f7e5a0f4f43a6e99847c4370df783c7142f71ba454"
   },
   "restricted": {

--- a/src/tests/data/sqs-events.ts
+++ b/src/tests/data/sqs-events.ts
@@ -120,6 +120,7 @@ export const VALID_AUTH_DELETE_ACCOUNT_TXMA_EVENT = {
   timestamp_formatted: "2023-04-19T11:00:01.000Z",
   user: {
     user_id: "01333e01-dde3-412f-a484-3333",
+    // pragma: allowlist nextline secret
     email: "e914e32172adcdad6c0906f7e5a0f4f43a6e99847c4370df783c7142f71ba454"
   }
 };

--- a/src/tests/data/sqs-events.ts
+++ b/src/tests/data/sqs-events.ts
@@ -65,7 +65,6 @@ export const VALID_AUTH_IPV_AUTHORISATION_REQUESTED_SQS_EVENT = {
 export const VALID_F2F_YOTI_START_TXMA_EVENT: ReturnSQSEvent = {
   "event_id": "588f4a66-f75a-4728-9f7b-8afd865c233d",
   "client_id": "ekwU",
-  "component_id": "UNKNOWN",
   "event_name": "F2F_YOTI_START",
   "timestamp": 1681902001,
   "timestamp_formatted": "2023-04-19T11:00:01.000Z",
@@ -80,7 +79,6 @@ export const VALID_F2F_YOTI_START_TXMA_EVENT_STRING = JSON.stringify(VALID_F2F_Y
 export const VALID_IPV_F2F_CRI_VC_CONSUMED_TXMA_EVENT: ReturnSQSEvent = {
   "event_id": "588f4a66-f75a-4728-9f7b-8afd865c233e",
   "client_id": "ekwU",
-  "component_id": "UNKNOWN",
   "event_name": "IPV_F2F_CRI_VC_CONSUMED",
   "timestamp": 1681902001,
   "timestamp_formatted": "2023-04-19T11:00:01.000Z",

--- a/src/tests/unit/GovNotifyHandler.test.ts
+++ b/src/tests/unit/GovNotifyHandler.test.ts
@@ -1,7 +1,7 @@
 import { mock } from "jest-mock-extended";
 import { lambdaHandler } from "../../GovNotifyHandler";
 import { SendEmailProcessor } from "../../services/SendEmailProcessor";
-import { VALID_SQS_EVENT } from "./data/sqs-events";
+import { VALID_GOV_NOTIFY_HANDLER_SQS_EVENT } from "./data/sqs-events";
 import { AppError } from "../../utils/AppError";
 import { HttpCodesEnum } from "../../models/enums/HttpCodesEnum";
 
@@ -21,7 +21,7 @@ jest.mock("../../utils/Config", () => {
 describe("GovNotifyHandler", () => {
 	it("return success response for govNotify", async () => {
 		SendEmailProcessor.getInstance = jest.fn().mockReturnValue(mockedSendEmailRequestProcessor);
-		await lambdaHandler(VALID_SQS_EVENT, "IPR");
+		await lambdaHandler(VALID_GOV_NOTIFY_HANDLER_SQS_EVENT, "IPR");
 
 		// eslint-disable-next-line @typescript-eslint/unbound-method
 		expect(mockedSendEmailRequestProcessor.processRequest).toHaveBeenCalledTimes(1);
@@ -37,7 +37,7 @@ describe("GovNotifyHandler", () => {
 		SendEmailProcessor.getInstance = jest.fn().mockImplementation(() => {
 			throw new AppError(HttpCodesEnum.SERVER_ERROR, "emailSending - failed: got error while sending email.");
 		});
-		const response = await lambdaHandler(VALID_SQS_EVENT, "IPR");
+		const response = await lambdaHandler(VALID_GOV_NOTIFY_HANDLER_SQS_EVENT, "IPR");
 		expect(response.batchItemFailures[0].itemIdentifier).toBe("");
 	});
 });

--- a/src/tests/unit/GovNotifyHandler.test.ts
+++ b/src/tests/unit/GovNotifyHandler.test.ts
@@ -1,7 +1,7 @@
 import { mock } from "jest-mock-extended";
 import { lambdaHandler } from "../../GovNotifyHandler";
 import { SendEmailProcessor } from "../../services/SendEmailProcessor";
-import { VALID_GOV_NOTIFY_HANDLER_SQS_EVENT } from "./data/sqs-events";
+import { VALID_GOV_NOTIFY_HANDLER_SQS_EVENT } from "../data/sqs-events";
 import { AppError } from "../../utils/AppError";
 import { HttpCodesEnum } from "../../models/enums/HttpCodesEnum";
 

--- a/src/tests/unit/PostEventHandler.test.ts
+++ b/src/tests/unit/PostEventHandler.test.ts
@@ -1,7 +1,7 @@
 import { mock } from "jest-mock-extended";
 import { lambdaHandler } from "../../PostEventHandler";
 import { PostEventProcessor } from "../../services/PostEventProcessor";
-import { VALID_AUTH_IPV_AUTHORISATION_REQUESTED_SQS_EVENT } from "./data/sqs-events";
+import { VALID_AUTH_IPV_AUTHORISATION_REQUESTED_SQS_EVENT } from "../data/sqs-events";
 import { AppError } from "../../utils/AppError";
 import { HttpCodesEnum } from "../../models/enums/HttpCodesEnum";
 

--- a/src/tests/unit/PostEventHandler.test.ts
+++ b/src/tests/unit/PostEventHandler.test.ts
@@ -1,7 +1,7 @@
 import { mock } from "jest-mock-extended";
 import { lambdaHandler } from "../../PostEventHandler";
 import { PostEventProcessor } from "../../services/PostEventProcessor";
-import { VALID_AUTH_IPV_AUTHORISATION_REQUESTED_EVENT } from "./data/sqs-events";
+import { VALID_AUTH_IPV_AUTHORISATION_REQUESTED_SQS_EVENT } from "./data/sqs-events";
 import { AppError } from "../../utils/AppError";
 import { HttpCodesEnum } from "../../models/enums/HttpCodesEnum";
 
@@ -21,7 +21,7 @@ jest.mock("../../utils/Config", () => {
 describe("PostEventHandler", () => {
 	it("returns success response", async () => {
 		PostEventProcessor.getInstance = jest.fn().mockReturnValue(mockPostEventProcessor);
-		await lambdaHandler(VALID_AUTH_IPV_AUTHORISATION_REQUESTED_EVENT, "IPR");
+		await lambdaHandler(VALID_AUTH_IPV_AUTHORISATION_REQUESTED_SQS_EVENT, "IPR");
 
 		// eslint-disable-next-line @typescript-eslint/unbound-method
 		expect(mockPostEventProcessor.processRequest).toHaveBeenCalledTimes(1);
@@ -37,7 +37,7 @@ describe("PostEventHandler", () => {
 		PostEventProcessor.getInstance = jest.fn().mockImplementation(() => {
 			throw new AppError(HttpCodesEnum.SERVER_ERROR, "Missing event config");
 		});
-		const response = await lambdaHandler(VALID_AUTH_IPV_AUTHORISATION_REQUESTED_EVENT, "IPR");
+		const response = await lambdaHandler(VALID_AUTH_IPV_AUTHORISATION_REQUESTED_SQS_EVENT, "IPR");
 		expect(response.batchItemFailures).toEqual([]);
 	});
 });

--- a/src/tests/unit/data/sqs-events.ts
+++ b/src/tests/unit/data/sqs-events.ts
@@ -1,47 +1,130 @@
-export const VALID_SQS_EVENT = {
-	"Records": [
-		{
-			"messageId": "6e67a34a-94f1-493f-b9eb-3d421aa701a8",
-			// pragma: allowlist nextline secret
-			"receiptHandle": "AQEBDzpW+TMqnd6I8zcqmrq8g8BTsuDjI745ci0bJ46g0Ej",
-			"body": "{\"Message\":{\"emailAddress\":\"bhavana.hemanth@digital.cabinet-office.gov.uk\",\"firstName\":\"Frederick\",\"lastName\":\"Flintstone\",\"messageType\":\"email\"}}",
-			"attributes": {
-				"ApproximateReceiveCount": "1",
-				"SentTimestamp": "1588867971441",
-				"SenderId": "AIDAIVEA3AGEU7NF6DRAG",
-				"ApproximateFirstReceiveTimestamp": "1588867971443",
-			},
-			"messageAttributes": {},
-			// pragma: allowlist nextline secret
-			"md5OfBody": "ef38e4dfa52ade850f671b7e1915f26b",
-			"eventSource": "aws:sqs",
-			"eventSourceARN": "queue_arn",
-			"awsRegion": "eu-west-2",
-		},
-	],
-}
-;
+export const VALID_GOV_NOTIFY_HANDLER_SQS_EVENT = {
+  "Records": [
+    {
+      "messageId": "6e67a34a-94f1-493f-b9eb-3d421aa701a8",
+      // pragma: allowlist nextline secret
+      "receiptHandle": "AQEBDzpW+TMqnd6I8zcqmrq8g8BTsuDjI745ci0bJ46g0Ej",
+      "body": "{\"Message\":{\"emailAddress\":\"bhavana.hemanth@digital.cabinet-office.gov.uk\",\"firstName\":\"Frederick\",\"lastName\":\"Flintstone\",\"messageType\":\"email\"}}",
+      "attributes": {
+        "ApproximateReceiveCount": "1",
+        "SentTimestamp": "1588867971441",
+        "SenderId": "AIDAIVEA3AGEU7NF6DRAG",
+        "ApproximateFirstReceiveTimestamp": "1588867971443",
+      },
+      "messageAttributes": {},
+      // pragma: allowlist nextline secret
+      "md5OfBody": "ef38e4dfa52ade850f671b7e1915f26b",
+      "eventSource": "aws:sqs",
+      "eventSourceARN": "queue_arn",
+      "awsRegion": "eu-west-2",
+    },
+  ],
+};
 
-export const VALID_AUTH_IPV_AUTHORISATION_REQUESTED_EVENT = {
-	"Records": [
-		{
-			"messageId": "6e67a34a-94f1-493f-b9eb-3d421aa701a8",
-			// pragma: allowlist nextline secret
-			"receiptHandle": "AQEBDzpW+TMqnd6I8zcqmrq8g8BTsuDjI745ci0bJ46g0Ej",
-			"body": "{\n\t\"event_id\": \"588f4a66-f75a-4728-9f7b-8afd865c233c\",\n\t\"client_id\": \"RqFZ83csmS4Mi4Y7s7ohD9-ekwU\",\n\t\"component_id\": \"UNKNOWN\",\n\t\"event_name\": \"AUTH_IPV_AUTHORISATION_REQUESTED\",\n\t\"timestamp\": 1681902001,\n\t\"timestamp_formatted\": \"2023-04-19T11:00:01.000Z\",\n\t\"user\": {\n\t\t\t\"user_id\": \"urn:fdc:gov.uk:2022:YbunsNpXM56SE0NMMcC0LmTRWrWMg33FqiFz-CWvxD8\",\n\t\t\t\"email\": \"e914e32172adcdad6c0906f7e5a0f4f43a6e99847c4370df783c7142f71ba454\"\n\t}\n}",
-			"attributes": {
-				"ApproximateReceiveCount": "1",
-				"SentTimestamp": "1588867971441",
-				"SenderId": "AIDAIVEA3AGEU7NF6DRAG",
-				"ApproximateFirstReceiveTimestamp": "1588867971443",
-			},
-			"messageAttributes": {},
-			// pragma: allowlist nextline secret
-			"md5OfBody": "ef38e4dfa52ade850f671b7e1915f26b",
-			"eventSource": "aws:sqs",
-			"eventSourceARN": "queue_arn",
-			"awsRegion": "eu-west-2",
-		},
-	],
-}
-;
+export const VALID_AUTH_IPV_AUTHORISATION_REQUESTED_TXMA_EVENT = {
+  event_id: "588f4a66-f75a-4728-9f7b-8afd865c233c",
+  client_id: "ekwU",
+  clientLandingPageUrl: "REDIRECT_URL",
+  event_name: "AUTH_IPV_AUTHORISATION_REQUESTED",
+  redirect_uri: "www.localhost.com",
+  rp_name: "replay",
+  timestamp: "1681902001",
+  timestamp_formatted: "2023-04-19T11:00:01.000Z",
+  user: {
+    user_id: "01333e01-dde3-412f-a484-5555",
+    email: "jest@test.com"
+  }
+};
+
+export const VALID_AUTH_IPV_AUTHORISATION_REQUESTED_TXMA_EVENT_STRING = JSON.stringify(VALID_AUTH_IPV_AUTHORISATION_REQUESTED_TXMA_EVENT);
+
+export const VALID_AUTH_IPV_AUTHORISATION_REQUESTED_SQS_EVENT = {
+  "Records": [
+    {
+      "messageId": "6e67a34a-94f1-493f-b9eb-3d421aa701a8",
+      // pragma: allowlist nextline secret
+      "receiptHandle": "AQEBDzpW+TMqnd6I8zcqmrq8g8BTsuDjI745ci0bJ46g0Ej",
+      "body": VALID_AUTH_IPV_AUTHORISATION_REQUESTED_TXMA_EVENT_STRING,
+      "attributes": {
+        "ApproximateReceiveCount": "1",
+        "SentTimestamp": "1588867971441",
+        "SenderId": "AIDAIVEA3AGEU7NF6DRAG",
+        "ApproximateFirstReceiveTimestamp": "1588867971443",
+      },
+      "messageAttributes": {},
+      // pragma: allowlist nextline secret
+      "md5OfBody": "ef38e4dfa52ade850f671b7e1915f26b",
+      "eventSource": "aws:sqs",
+      "eventSourceARN": "queue_arn",
+      "awsRegion": "eu-west-2",
+    },
+  ],
+};
+
+export const VALID_F2F_YOTI_START_TXMA_EVENT = {
+  "event_id": "588f4a66-f75a-4728-9f7b-8afd865c233d",
+  "client_id": "ekwU",
+  "component_id": "UNKNOWN",
+  "event_name": "F2F_YOTI_START",
+  "redirect_uri": "www.localhost.com",
+  "rp_name": "replay",
+  "timestamp": 1681902001,
+  "timestamp_formatted": "2023-04-19T11:00:01.000Z",
+  "user": {
+    "user_id": "01333e01-dde3-412f-a484-4444",
+    "email": "jest@test.com"
+  }
+};
+
+export const VALID_F2F_YOTI_START_TXMA_EVENT_STRING = JSON.stringify(VALID_F2F_YOTI_START_TXMA_EVENT);
+
+export const VALID_IPV_F2F_CRI_VC_CONSUMED_TXMA_EVENT = {
+  "event_id": "588f4a66-f75a-4728-9f7b-8afd865c233e",
+  "client_id": "ekwU",
+  "component_id": "UNKNOWN",
+  "event_name": "IPV_F2F_CRI_VC_CONSUMED",
+  "redirect_uri": "www.localhost.com",
+  "rp_name": "replay",
+  "timestamp": 1681902001,
+  "timestamp_formatted": "2023-04-19T11:00:01.000Z",
+  "user": {
+    "user_id": "01333e01-dde3-412f-a484-4444",
+    "email": "e914e32172adcdad6c0906f7e5a0f4f43a6e99847c4370df783c7142f71ba454"
+  },
+  "restricted": {
+    "nameParts": [
+      {
+        "type": "GivenName",
+        "value": "ANGELA"
+      },
+      {
+        "type": "GivenName",
+        "value": "ZOE"
+      },
+      {
+        "type": "FamilyName",
+        "value": "UK SPECIMEN"
+      }
+    ]
+  }
+
+};
+
+export const VALID_IPV_F2F_CRI_VC_CONSUMED_TXMA_EVENT_STRING = JSON.stringify(VALID_IPV_F2F_CRI_VC_CONSUMED_TXMA_EVENT);
+
+export const VALID_AUTH_DELETE_ACCOUNT_TXMA_EVENT = {
+  event_id: "588f4a66-f75a-4728-9f7b-8afd865c233f",
+  client_id: "ekwU",
+  component_id: "UNKNOWN",
+  event_name: "AUTH_DELETE_ACCOUNT",
+  redirect_uri: "www.localhost.com",
+  rp_name: "replay",
+  timestamp: 1681902001,
+  timestamp_formatted: "2023-04-19T11:00:01.000Z",
+  user: {
+    user_id: "01333e01-dde3-412f-a484-3333",
+    email: "e914e32172adcdad6c0906f7e5a0f4f43a6e99847c4370df783c7142f71ba454"
+  }
+};
+
+export const VALID_AUTH_DELETE_ACCOUNT_TXMA_EVENT_STRING = JSON.stringify(VALID_AUTH_DELETE_ACCOUNT_TXMA_EVENT);

--- a/src/tests/unit/data/sqs-events.ts
+++ b/src/tests/unit/data/sqs-events.ts
@@ -1,3 +1,5 @@
+import {EventType, ReturnSQSEvent} from "../../../models/ReturnSQSEvent";
+
 export const VALID_GOV_NOTIFY_HANDLER_SQS_EVENT = {
   "Records": [
     {
@@ -21,14 +23,13 @@ export const VALID_GOV_NOTIFY_HANDLER_SQS_EVENT = {
   ],
 };
 
-export const VALID_AUTH_IPV_AUTHORISATION_REQUESTED_TXMA_EVENT = {
+export const VALID_AUTH_IPV_AUTHORISATION_REQUESTED_TXMA_EVENT: ReturnSQSEvent = {
   event_id: "588f4a66-f75a-4728-9f7b-8afd865c233c",
   client_id: "ekwU",
   clientLandingPageUrl: "REDIRECT_URL",
   event_name: "AUTH_IPV_AUTHORISATION_REQUESTED",
-  redirect_uri: "www.localhost.com",
-  rp_name: "replay",
-  timestamp: "1681902001",
+  // rp_name: "replay",
+  timestamp: 1681902001,
   timestamp_formatted: "2023-04-19T11:00:01.000Z",
   user: {
     user_id: "01333e01-dde3-412f-a484-5555",
@@ -61,13 +62,11 @@ export const VALID_AUTH_IPV_AUTHORISATION_REQUESTED_SQS_EVENT = {
   ],
 };
 
-export const VALID_F2F_YOTI_START_TXMA_EVENT = {
+export const VALID_F2F_YOTI_START_TXMA_EVENT: ReturnSQSEvent = {
   "event_id": "588f4a66-f75a-4728-9f7b-8afd865c233d",
   "client_id": "ekwU",
   "component_id": "UNKNOWN",
   "event_name": "F2F_YOTI_START",
-  "redirect_uri": "www.localhost.com",
-  "rp_name": "replay",
   "timestamp": 1681902001,
   "timestamp_formatted": "2023-04-19T11:00:01.000Z",
   "user": {
@@ -78,13 +77,11 @@ export const VALID_F2F_YOTI_START_TXMA_EVENT = {
 
 export const VALID_F2F_YOTI_START_TXMA_EVENT_STRING = JSON.stringify(VALID_F2F_YOTI_START_TXMA_EVENT);
 
-export const VALID_IPV_F2F_CRI_VC_CONSUMED_TXMA_EVENT = {
+export const VALID_IPV_F2F_CRI_VC_CONSUMED_TXMA_EVENT: ReturnSQSEvent = {
   "event_id": "588f4a66-f75a-4728-9f7b-8afd865c233e",
   "client_id": "ekwU",
   "component_id": "UNKNOWN",
   "event_name": "IPV_F2F_CRI_VC_CONSUMED",
-  "redirect_uri": "www.localhost.com",
-  "rp_name": "replay",
   "timestamp": 1681902001,
   "timestamp_formatted": "2023-04-19T11:00:01.000Z",
   "user": {
@@ -118,7 +115,6 @@ export const VALID_AUTH_DELETE_ACCOUNT_TXMA_EVENT = {
   component_id: "UNKNOWN",
   event_name: "AUTH_DELETE_ACCOUNT",
   redirect_uri: "www.localhost.com",
-  rp_name: "replay",
   timestamp: 1681902001,
   timestamp_formatted: "2023-04-19T11:00:01.000Z",
   user: {

--- a/src/tests/unit/services/PostEventProcessor.test.ts
+++ b/src/tests/unit/services/PostEventProcessor.test.ts
@@ -37,7 +37,7 @@ describe("PostEventProcessor", () => {
 		await postEventProcessor.processRequest(VALID_AUTH_IPV_AUTHORISATION_REQUESTED_TXMA_EVENT_STRING);
 		const expiresOn = absoluteTimeNow() + Number(process.env.SESSION_RETURN_RECORD_TTL!);
 		// eslint-disable-next-line @typescript-eslint/unbound-method
-		expect(mockIprService.saveEventData).toHaveBeenCalledWith("01333e01-dde3-412f-a484-5555", "SET ipvStartedOn = :ipvStartedOn, userEmail = :userEmail, clientName = :clientName,  redirectUri = :redirectUri, expiresOn = :expiresOn", { ":clientName": "ekwU", ":ipvStartedOn": "1681902001", ":redirectUri": "REDIRECT_URL", ":userEmail": "jest@test.com", ":expiresOn": expiresOn });
+		expect(mockIprService.saveEventData).toHaveBeenCalledWith("01333e01-dde3-412f-a484-5555", "SET ipvStartedOn = :ipvStartedOn, userEmail = :userEmail, clientName = :clientName,  redirectUri = :redirectUri, expiresOn = :expiresOn", { ":clientName": "ekwU", ":ipvStartedOn": 1681902001, ":redirectUri": "REDIRECT_URL", ":userEmail": "jest@test.com", ":expiresOn": expiresOn });
 	});
 
 	it("Calls saveEventData with appropriate payload for F2F_YOTI_START_EVENT event", async () => {

--- a/src/tests/unit/services/PostEventProcessor.test.ts
+++ b/src/tests/unit/services/PostEventProcessor.test.ts
@@ -11,7 +11,7 @@ import {
 	VALID_AUTH_IPV_AUTHORISATION_REQUESTED_TXMA_EVENT_STRING,
 	VALID_F2F_YOTI_START_TXMA_EVENT_STRING,
 	VALID_IPV_F2F_CRI_VC_CONSUMED_TXMA_EVENT_STRING,
-} from "../data/sqs-events";
+} from "../../data/sqs-events";
 
 let postEventProcessor: PostEventProcessor;
 const mockIprService = mock<IPRService>();

--- a/src/tests/unit/services/PostEventProcessor.test.ts
+++ b/src/tests/unit/services/PostEventProcessor.test.ts
@@ -6,17 +6,18 @@ import { IPRService } from "../../../services/IPRService";
 import { HttpCodesEnum } from "../../../models/enums/HttpCodesEnum";
 import { absoluteTimeNow } from "../../../utils/DateTimeUtils";
 import { AppError } from "../../../utils/AppError";
+import {
+	VALID_AUTH_DELETE_ACCOUNT_TXMA_EVENT_STRING,
+	VALID_AUTH_IPV_AUTHORISATION_REQUESTED_TXMA_EVENT_STRING,
+	VALID_F2F_YOTI_START_TXMA_EVENT_STRING,
+	VALID_IPV_F2F_CRI_VC_CONSUMED_TXMA_EVENT_STRING,
+} from "../data/sqs-events";
 
 let postEventProcessor: PostEventProcessor;
 const mockIprService = mock<IPRService>();
 const mockLogger = mock<Logger>();
 
 const metrics = new Metrics({ namespace: "F2F" });
-const AUTH_IPV_AUTHORISATION_REQUESTED_EVENT = "{\n\t\"event_id\":\"588f4a66-f75a-4728-9f7b-8afd865c233c\",\n\t\"client_id\":\"ekwU\",\n\t\"clientLandingPageUrl\":\"REDIRECT_URL\",\n\t\"event_name\":\"AUTH_IPV_AUTHORISATION_REQUESTED\",\n\t\"redirect_uri\":\"www.localhost.com\",\n\t\"rp_name\":\"replay\",\n\t\"timestamp\":\"1681902001\",\n\t\"timestamp_formatted\":\"2023-04-19T11:00:01.000Z\",\n\t\"user\":{\n\t\t \"user_id\":\"01333e01-dde3-412f-a484-5555\",\n\t\t \"email\":\"jest@test.com\"\n\t}\n}";
-const F2F_YOTI_START_EVENT = "{\n   \"event_id\":\"588f4a66-f75a-4728-9f7b-8afd865c233d\",\n   \"client_id\":\"ekwU\",\n   \"component_id\":\"UNKNOWN\",\n   \"event_name\":\"F2F_YOTI_START\",\n   \"redirect_uri\":\"www.localhost.com\",\n   \"rp_name\":\"replay\",\n   \"timestamp\":1681902001,\n   \"timestamp_formatted\":\"2023-04-19T11:00:01.000Z\",\n   \"user\":{\n\t\t \"user_id\":\"01333e01-dde3-412f-a484-4444\",\n\t\t \"email\":\"jest@test.com\"\n\t}\n}";
-const IPV_F2F_CRI_VC_CONSUMED_EVENT = "{\"event_id\":\"588f4a66-f75a-4728-9f7b-8afd865c233e\",\"client_id\":\"ekwU\",\"component_id\":\"UNKNOWN\",\"event_name\":\"IPV_F2F_CRI_VC_CONSUMED\",\"redirect_uri\":\"www.localhost.com\",\"rp_name\":\"replay\",\"timestamp\":1681902001,\"timestamp_formatted\":\"2023-04-19T11:00:01.000Z\",\"user\":{\"user_id\":\"01333e01-dde3-412f-a484-4444\",\"email\":\"e914e32172adcdad6c0906f7e5a0f4f43a6e99847c4370df783c7142f71ba454\"},\"restricted\":{\"nameParts\":[{\"type\":\"GivenName\",\"value\":\"ANGELA\"},{\"type\":\"GivenName\",\"value\":\"ZOE\"},{\"type\":\"FamilyName\",\"value\":\"UK SPECIMEN\"}]}}";
-const AUTH_DELETE_ACCOUNT_EVENT = "{\n   \"event_id\":\"588f4a66-f75a-4728-9f7b-8afd865c233f\",\n   \"client_id\":\"ekwU\",\n   \"component_id\":\"UNKNOWN\",\n   \"event_name\":\"AUTH_DELETE_ACCOUNT\",\n   \"redirect_uri\":\"www.localhost.com\",\n   \"rp_name\":\"replay\",\n   \"timestamp\":1681902001,\n   \"timestamp_formatted\":\"2023-04-19T11:00:01.000Z\",\n   \"user\":{\n      \"user_id\":\"01333e01-dde3-412f-a484-3333\",\n      \"email\":\"e914e32172adcdad6c0906f7e5a0f4f43a6e99847c4370df783c7142f71ba454\"\n   }\n}";
-
 
 describe("PostEventProcessor", () => {
 	beforeAll(() => {
@@ -27,32 +28,32 @@ describe("PostEventProcessor", () => {
 	});
 
 	it("Returns success response when call to save event data is successful", async () => {
-		const response = await postEventProcessor.processRequest(AUTH_IPV_AUTHORISATION_REQUESTED_EVENT);
+		const response = await postEventProcessor.processRequest(VALID_AUTH_IPV_AUTHORISATION_REQUESTED_TXMA_EVENT_STRING);
 		expect(response.statusCode).toBe(HttpCodesEnum.CREATED);
 		expect(response.eventBody).toBe("OK");
 	});
 
 	it("Calls saveEventData with appropriate payload for AUTH_IPV_AUTHORISATION_REQUESTED event", async () => {
-		await postEventProcessor.processRequest(AUTH_IPV_AUTHORISATION_REQUESTED_EVENT);
+		await postEventProcessor.processRequest(VALID_AUTH_IPV_AUTHORISATION_REQUESTED_TXMA_EVENT_STRING);
 		const expiresOn = absoluteTimeNow() + Number(process.env.SESSION_RETURN_RECORD_TTL!);
 		// eslint-disable-next-line @typescript-eslint/unbound-method
 		expect(mockIprService.saveEventData).toHaveBeenCalledWith("01333e01-dde3-412f-a484-5555", "SET ipvStartedOn = :ipvStartedOn, userEmail = :userEmail, clientName = :clientName,  redirectUri = :redirectUri, expiresOn = :expiresOn", { ":clientName": "ekwU", ":ipvStartedOn": "1681902001", ":redirectUri": "REDIRECT_URL", ":userEmail": "jest@test.com", ":expiresOn": expiresOn });
 	});
 
 	it("Calls saveEventData with appropriate payload for F2F_YOTI_START_EVENT event", async () => {
-		await postEventProcessor.processRequest(F2F_YOTI_START_EVENT);
+		await postEventProcessor.processRequest(VALID_F2F_YOTI_START_TXMA_EVENT_STRING);
 		// eslint-disable-next-line @typescript-eslint/unbound-method
 		expect(mockIprService.saveEventData).toHaveBeenCalledWith("01333e01-dde3-412f-a484-4444", "SET journeyWentAsyncOn = :journeyWentAsyncOn", { ":journeyWentAsyncOn": 1681902001 });
 	});
 
 	it("Calls saveEventData with appropriate payload for IPV_F2F_CRI_VC_CONSUMED_EVENT event", async () => {
-		await postEventProcessor.processRequest(IPV_F2F_CRI_VC_CONSUMED_EVENT);
+		await postEventProcessor.processRequest(VALID_IPV_F2F_CRI_VC_CONSUMED_TXMA_EVENT_STRING);
 		// eslint-disable-next-line @typescript-eslint/unbound-method
 		expect(mockIprService.saveEventData).toHaveBeenCalledWith("01333e01-dde3-412f-a484-4444", "SET readyToResumeOn = :readyToResumeOn, nameParts = :nameParts", { ":readyToResumeOn": 1681902001, ":nameParts": [{ "type": "GivenName", "value": "ANGELA" }, { "type": "GivenName", "value": "ZOE" }, { "type":"FamilyName", "value":"UK SPECIMEN" }] });
 	});
 
 	it("Calls saveEventData with appropriate payload for AUTH_DELETE_ACCOUNT_EVENT event", async () => {
-		await postEventProcessor.processRequest(AUTH_DELETE_ACCOUNT_EVENT);
+		await postEventProcessor.processRequest(VALID_AUTH_DELETE_ACCOUNT_TXMA_EVENT_STRING);
 		// eslint-disable-next-line @typescript-eslint/unbound-method
 		expect(mockIprService.saveEventData).toHaveBeenCalledWith("01333e01-dde3-412f-a484-3333", "SET accountDeletedOn = :accountDeletedOn, userEmail = :userEmail, nameParts = :nameParts, clientName = :clientName,  redirectUri = :redirectUri", { ":accountDeletedOn": 1681902001, ":clientName": "", ":nameParts": [], ":redirectUri": "", ":userEmail": "" });
 	});

--- a/src/tests/unit/services/SendEmailProcessor.test.ts
+++ b/src/tests/unit/services/SendEmailProcessor.test.ts
@@ -1,7 +1,7 @@
 import { Metrics } from "@aws-lambda-powertools/metrics";
 import { Logger } from "@aws-lambda-powertools/logger";
 import { SQSEvent } from "aws-lambda";
-import { VALID_SQS_EVENT } from "../data/sqs-events";
+import { VALID_GOV_NOTIFY_HANDLER_SQS_EVENT } from "../data/sqs-events";
 import { SendEmailProcessor } from "../../../services/SendEmailProcessor";
 import { SendEmailService } from "../../../services/SendEmailService";
 import { IPRService } from "../../../services/IPRService";
@@ -28,12 +28,12 @@ describe("SendEmailProcessor", () => {
 		sendEmailProcessorTest.govNotifyService = mockGovNotifyService;
 		// @ts-ignore
 		sendEmailProcessorTest.iprService = mockIprService;
-		sqsEvent = VALID_SQS_EVENT;
+		sqsEvent = VALID_GOV_NOTIFY_HANDLER_SQS_EVENT;
 	});
 
 	beforeEach(() => {
 		jest.clearAllMocks();
-		sqsEvent = VALID_SQS_EVENT;
+		sqsEvent = VALID_GOV_NOTIFY_HANDLER_SQS_EVENT;
 	});
 
 	it("Returns success response when all required Email attributes exists", async () => {

--- a/src/tests/unit/services/SendEmailProcessor.test.ts
+++ b/src/tests/unit/services/SendEmailProcessor.test.ts
@@ -1,7 +1,7 @@
 import { Metrics } from "@aws-lambda-powertools/metrics";
 import { Logger } from "@aws-lambda-powertools/logger";
 import { SQSEvent } from "aws-lambda";
-import { VALID_GOV_NOTIFY_HANDLER_SQS_EVENT } from "../data/sqs-events";
+import { VALID_GOV_NOTIFY_HANDLER_SQS_EVENT } from "../../data/sqs-events";
 import { SendEmailProcessor } from "../../../services/SendEmailProcessor";
 import { SendEmailService } from "../../../services/SendEmailService";
 import { IPRService } from "../../../services/IPRService";

--- a/src/tests/unit/services/SendEmailService.test.ts
+++ b/src/tests/unit/services/SendEmailService.test.ts
@@ -2,7 +2,7 @@ import { Logger } from "@aws-lambda-powertools/logger";
 import { SQSEvent } from "aws-lambda";
 // @ts-ignore
 import { NotifyClient } from "notifications-node-client";
-import { VALID_GOV_NOTIFY_HANDLER_SQS_EVENT } from "../data/sqs-events";
+import { VALID_GOV_NOTIFY_HANDLER_SQS_EVENT } from "../../data/sqs-events";
 import { SendEmailProcessor } from "../../../services/SendEmailProcessor";
 import { SendEmailService } from "../../../services/SendEmailService";
 import { mock } from "jest-mock-extended";

--- a/src/tests/unit/services/SendEmailService.test.ts
+++ b/src/tests/unit/services/SendEmailService.test.ts
@@ -2,7 +2,7 @@ import { Logger } from "@aws-lambda-powertools/logger";
 import { SQSEvent } from "aws-lambda";
 // @ts-ignore
 import { NotifyClient } from "notifications-node-client";
-import { VALID_SQS_EVENT } from "../data/sqs-events";
+import { VALID_GOV_NOTIFY_HANDLER_SQS_EVENT } from "../data/sqs-events";
 import { SendEmailProcessor } from "../../../services/SendEmailProcessor";
 import { SendEmailService } from "../../../services/SendEmailService";
 import { mock } from "jest-mock-extended";
@@ -23,12 +23,12 @@ describe("SendEmailProcessor", () => {
 		sendEmailServiceTest = SendEmailService.getInstance(logger, GOVUKNOTIFY_API_KEY);
 		// @ts-ignore
 		sendEmailServiceTest.govNotify = mockGovNotify;
-		sqsEvent = VALID_SQS_EVENT;
+		sqsEvent = VALID_GOV_NOTIFY_HANDLER_SQS_EVENT;
 	});
 
 	beforeEach(() => {
 		jest.clearAllMocks();
-		sqsEvent = VALID_SQS_EVENT;
+		sqsEvent = VALID_GOV_NOTIFY_HANDLER_SQS_EVENT;
 	});
 
 	it("Returns EmailResponse when email is sent successfully", async () => {


### PR DESCRIPTION
## Proposed changes

### What changed

Add an API test harness which can be used to exercise a deployed instance of this code in AWS by injecting test events in to the mock TXMA consumer queue, and checking for the required state to be reached eventually in the DynamoDB table.

### Why did it change

So to enable live / dynamic testing in pipeline on the route-to-live.

### Issue tracking

- [F2F-870](https://govukverify.atlassian.net/browse/F2F-870)

## Checklists

### PII logging

- [X] Verified that no PII data is being logged

### Environment variables or secrets

- [X] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [X] Update [README](./blob/main/README.md) with any new instructions or tasks


[F2F-870]: https://govukverify.atlassian.net/browse/F2F-870?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ