### PR TITLE
[F2F-490]Adding unit-tests for testing GovNotify re-try logic

### DIFF
--- a/src/jest.setup.ts
+++ b/src/jest.setup.ts
@@ -11,5 +11,5 @@ process.env.CLIENT_ID_SSM_PATH = "oidc-client-id_SSM_PATH";
 process.env.OIDC_URL = "oidc-url";
 process.env.RETURN_REDIRECT_URL = "ipv-return-redirect-url";
 process.env.ASSUMEROLE_WITH_WEB_IDENTITY_ARN = "assume-role-arn";
-process.env.GOVUKNOTIFY_BACKOFF_PERIOD_MS = "5000";
+process.env.GOVUKNOTIFY_BACKOFF_PERIOD_MS = "10";
 

--- a/src/tests/unit/services/SendEmailService.test.ts
+++ b/src/tests/unit/services/SendEmailService.test.ts
@@ -42,13 +42,69 @@ describe("SendEmailProcessor", () => {
 		expect(emailResponse.emailFailureMessage).toBe("");
 	});
 
-	it("SendEmailService fails when GovNotify throws an error", async () => {
-		mockGovNotify.sendEmail.mockImplementation(() => {
-			throw new AppError(HttpCodesEnum.BAD_REQUEST, "Using team-only API key");
+	it("SendEmailService fails and doesnt retry when GovNotify throws an error", async () => {
+		mockGovNotify.sendEmail = jest.fn().mockRejectedValue( {
+			"response": {
+				"data": {
+					"errors": [
+						{
+							"error": "BadRequestError",
+							"message": "Can't send to this recipient using a team-only API key",
+						},
+					],
+					"status_code": 400,
+				},
+
+			},
 		});
 		const eventBody = JSON.parse(sqsEvent.Records[0].body);
 		const email = Email.parseRequest(JSON.stringify(eventBody.Message));
 		await expect(sendEmailServiceTest.sendEmail(email)).rejects.toThrow();
+		expect(mockGovNotify.sendEmail).toHaveBeenCalledTimes(1);
+	});
+
+	it("SendEmailService retries when GovNotify throws a 500 error", async () => {
+		mockGovNotify.sendEmail = jest.fn().mockRejectedValue( {
+			"response": {
+				"data": {
+					"errors": [
+						{
+							"error": "Exception",
+							"message": "Internal server error",
+						},
+					],
+					"status_code": 500,
+				},
+
+			},
+		});
+
+		const eventBody = JSON.parse(sqsEvent.Records[0].body);
+		const email = Email.parseRequest(JSON.stringify(eventBody.Message));
+		await expect(sendEmailServiceTest.sendEmail(email)).rejects.toThrow();
+		expect(mockGovNotify.sendEmail).toHaveBeenCalledTimes(4);
+	});
+
+	it("SendEmailService retries when GovNotify throws a 429 error", async () => {
+		mockGovNotify.sendEmail = jest.fn().mockRejectedValue( {
+			"response": {
+				"data": {
+					"errors": [
+						{
+							"error": "TooManyRequestsError",
+							"message": "Exceeded send limits (LIMIT NUMBER) for today",
+						},
+					],
+					"status_code": 429,
+				},
+
+			},
+		});
+
+		const eventBody = JSON.parse(sqsEvent.Records[0].body);
+		const email = Email.parseRequest(JSON.stringify(eventBody.Message));
+		await expect(sendEmailServiceTest.sendEmail(email)).rejects.toThrow();
+		expect(mockGovNotify.sendEmail).toHaveBeenCalledTimes(4);
 	});
 
 });

--- a/src/tests/unit/services/SendEmailService.test.ts
+++ b/src/tests/unit/services/SendEmailService.test.ts
@@ -43,7 +43,7 @@ describe("SendEmailProcessor", () => {
 	});
 
 	it("SendEmailService fails and doesnt retry when GovNotify throws an error", async () => {
-		mockGovNotify.sendEmail = jest.fn().mockRejectedValue( {
+		mockGovNotify.sendEmail.mockRejectedValue( {
 			"response": {
 				"data": {
 					"errors": [
@@ -64,7 +64,7 @@ describe("SendEmailProcessor", () => {
 	});
 
 	it("SendEmailService retries when GovNotify throws a 500 error", async () => {
-		mockGovNotify.sendEmail = jest.fn().mockRejectedValue( {
+		mockGovNotify.sendEmail.mockRejectedValue( {
 			"response": {
 				"data": {
 					"errors": [
@@ -86,7 +86,7 @@ describe("SendEmailProcessor", () => {
 	});
 
 	it("SendEmailService retries when GovNotify throws a 429 error", async () => {
-		mockGovNotify.sendEmail = jest.fn().mockRejectedValue( {
+		mockGovNotify.sendEmail.mockRejectedValue( {
 			"response": {
 				"data": {
 					"errors": [


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[F2F-XXX] PR Title` -->

## Proposed changes

### What changed

Added unit-tests in GovNotify to test the re-tries logic.

### Why did it change

BAQAing this ticket required a way to test GovNotify retry logic incase we receive 500/429 errors

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [F2F-490](https://govukverify.atlassian.net/browse/F2F-490)


[F2F-490]: https://govukverify.atlassian.net/browse/F2F-490?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ