### PR TITLE
Gov notify IPV return templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,4 @@
 # di-ipvreturn-api
+
+# Gov Notify Templates
+The gov-notify-templates directory contains the templates required for sending email notification to the user. The name of the file matches the name of the template in the Gov notify portal for "IPVReturn Production" service. The content of the file has the subject line and the message which should be copied without any changes as it includes gov notify formatting markdown.

--- a/gov-notify-templates/ReturnJourneyEmail
+++ b/gov-notify-templates/ReturnJourneyEmail
@@ -1,0 +1,19 @@
+Subject:
+Sign in to view the result of your identity check
+
+Message:
+Dear ((first name)) ((last name)),
+
+You recently took your photo ID and customer letter to a Post Office.
+
+To view the result of your identity check, you need to sign in to your GOV.​UK One Login: ((return_journey_URL))
+
+Then you’ll be sent to the service you need to use.
+
+After you continue, you’ll be able to view the result of your identity check.
+
+If you need help, contact us: https://signin.account.gov.uk/contact-us
+
+Regards,
+
+GOV.​UK One Login team


### PR DESCRIPTION
## Proposed changes
Added a file with IPV Return gov notify email template with formatting.

### Why did it change

We need a permanent location to store Gov notify template backups.

### Issue tracking

- [F2F-386](https://govukverify.atlassian.net/browse/F2F-386)

## Checklists

### Environment variables or secrets

- [ ] No environment variables or secrets were added or changed

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks

Return journey Email template in 
![image](https://github.com/alphagov/di-ipvreturn-api/assets/133013208/4d414099-5853-4605-bcc7-5a458ff41ba9)


[F2F-359]: https://govukverify.atlassian.net/browse/F2F-359?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[F2F-386]: https://govukverify.atlassian.net/browse/F2F-386?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ