### PR TITLE
F2F-874 Logs govuk_signin_journey_id in postEvent processor

### DIFF
--- a/src/models/ReturnSQSEvent.ts
+++ b/src/models/ReturnSQSEvent.ts
@@ -12,6 +12,7 @@ export interface ReturnSQSEvent {
 	user: {
 		user_id: string;
 		email?: string;
+		govuk_signin_journey_id?: string;
 	};
 	restricted?: {
 		nameParts: NamePart[];

--- a/src/services/PostEventProcessor.ts
+++ b/src/services/PostEventProcessor.ts
@@ -64,6 +64,7 @@ export class PostEventProcessor {
 				throw new AppError(HttpCodesEnum.SERVER_ERROR, "Missing info in sqs event");
 			}
 			const userDetails = eventDetails.user;
+			this.logger.appendKeys({ govuk_signin_journey_id: userDetails.govuk_signin_journey_id });
 
 			if (!this.checkIfValidString([userDetails.user_id])) {
 				this.logger.error({ message: "Missing or invalid value for userDetails.user_id in event payload" }, { messageCode: MessageCodes.MISSING_MANDATORY_FIELDS });

--- a/src/services/SendEmailProcessor.ts
+++ b/src/services/SendEmailProcessor.ts
@@ -1,6 +1,5 @@
 import { Email } from "../models/Email";
 import { EmailResponse } from "../models/EmailResponse";
-import { ServicesEnum } from "../models/enums/ServicesEnum";
 import { ValidationHelper } from "../utils/ValidationHelper";
 import { createDynamoDbClient } from "../utils/DynamoDBFactory";
 import { buildCoreEventFields } from "../utils/TxmaEvent";
@@ -8,11 +7,9 @@ import { Logger } from "@aws-lambda-powertools/logger";
 import { Metrics } from "@aws-lambda-powertools/metrics";
 import { SendEmailService } from "./SendEmailService";
 import { IPRService } from "./IPRService";
-import { EnvironmentVariables } from "./EnvironmentVariables";
 import { MessageCodes } from "../models/enums/MessageCodes";
 import { AppError } from "../utils/AppError";
 import { HttpCodesEnum } from "../models/enums/HttpCodesEnum";
-import { Response } from "../utils/Response";
 import { SessionEvent } from "../models/SessionEvent";
 
 export class SendEmailProcessor {

--- a/src/services/SessionProcessor.ts
+++ b/src/services/SessionProcessor.ts
@@ -1,23 +1,24 @@
 import { Logger } from "@aws-lambda-powertools/logger";
 import { Metrics } from "@aws-lambda-powertools/metrics";
+import { randomUUID } from "crypto";
+import { APIGatewayProxyEvent } from "aws-lambda";
+import axios from "axios";
+import { IPRService } from "./IPRService";
+import { EnvironmentVariables } from "./EnvironmentVariables";
 import { KmsJwtAdapter } from "../utils/KmsJwtAdapter";
 import { HttpCodesEnum } from "../utils/HttpCodesEnum";
-import { APIGatewayProxyEvent } from "aws-lambda";
 import { Response } from "../utils/Response";
 import { absoluteTimeNow } from "../utils/DateTimeUtils";
 import { buildCoreEventFields } from "../utils/TxmaEvent";
-import { randomUUID } from "crypto";
-import axios from "axios";
 import { AppError } from "../utils/AppError";
 import { createDynamoDbClientWithCreds } from "../utils/DynamoDBFactory";
-import { IPRService } from "./IPRService";
-import { EnvironmentVariables } from "./EnvironmentVariables";
-import { ServicesEnum } from "../models/enums/ServicesEnum";
 import { ValidationHelper } from "../utils/ValidationHelper";
 import { Jwt, JwtPayload } from "../utils/IVeriCredential";
 import { Constants } from "../utils/Constants";
-import { SessionEventStatusEnum } from "../models/enums/SessionEventStatusEnum";
 import { stsClient } from "../utils/StsClient";
+import { ServicesEnum } from "../models/enums/ServicesEnum";
+import { SessionEventStatusEnum } from "../models/enums/SessionEventStatusEnum";
+import { MessageCodes } from "../models/enums/MessageCodes";
 
 export class SessionProcessor {
 	private static instance: SessionProcessor;
@@ -156,10 +157,18 @@ export class SessionProcessor {
 			}
 			this.logger.info("User is successfully redirected to : ", session?.redirectUri);
 
-			await iprService.sendToTXMA({
-				event_name: "IPR_USER_REDIRECTED",
-				...buildCoreEventFields({ user_id: sub }),
-			});
+			try {
+				await iprService.sendToTXMA({
+					event_name: "IPR_USER_REDIRECTED",
+					...buildCoreEventFields({ user_id: sub }),
+				});
+			} catch (error) {
+				this.logger.error("Failed to send IPR_USER_REDIRECTED event to TXMA", {
+					error,
+					messageCode: MessageCodes.FAILED_TO_WRITE_TXMA,
+				});
+			}
+
 
 			return {
 				statusCode: HttpCodesEnum.OK,


### PR DESCRIPTION
## Proposed changes

### What changed

Logs `govuk_signin_journey_id` from events coming into PostEventProcessor 

### Why did it change

To help debugging in the future

### Screenshots
<img width="891" alt="Screenshot 2023-07-04 at 4 00 41 pm" src="https://github.com/alphagov/di-ipvreturn-api/assets/40401118/bffd2c8c-b516-45ec-a7e2-aad3a03465c3">
<img width="922" alt="Screenshot 2023-07-04 at 4 04 53 pm" src="https://github.com/alphagov/di-ipvreturn-api/assets/40401118/674119ba-dbc6-4d08-96ea-70b9d20ed22a">
<img width="907" alt="Screenshot 2023-07-04 at 4 06 05 pm" src="https://github.com/alphagov/di-ipvreturn-api/assets/40401118/eca6e06c-0870-4a74-880a-7e71510be3ce">


### Issue tracking
- [F2F-874](https://govukverify.atlassian.net/browse/F2F-874)

## Checklists

### PII logging

- [x] Verified that no PII data is being logged


[F2F-874]: https://govukverify.atlassian.net/browse/F2F-874?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ