### PR TITLE
[F2F-802] Updated templateId to use Live one on Prod

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -129,7 +129,7 @@ Mappings:
       RETURNREDIRECTURL: "https://return.integration.account.gov.uk/callback"
       LAMBDACONCURRENCYTHRESHOLD: 16
     production:
-      GOVUKNOTIFYTEMPLATEID: "3baf3b59-2396-44c8-b7a4-b5a981fad5e8"
+      GOVUKNOTIFYTEMPLATEID: "206971e2-d576-4d12-b34f-b0de442d39ab"
       MESSAGERETENTIONPERIODDAYS: 345600 # Default: 4 days
       TXMAMESSAGERETENTIONPERIODDAYS: 604800 # Default: 7 days
       RETURNJOURNEYURL: "https://return.account.gov.uk/resume"


### PR DESCRIPTION

## Proposed changes

### What changed

Add the new template-id for the Gov notify email template from `GOV.UK One Login - Prove your identity at a Post Office `service

### Why did it change

To use the Live service for sending emails

### Issue tracking

- [F2F-802](https://govukverify.atlassian.net/browse/F2F-802)

## Checklists

### PII logging

- [ ] Verified that no PII data is being logged

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[F2F-802]: https://govukverify.atlassian.net/browse/F2F-802?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ