### PR TITLE
[F2F-1001] Changes validation issues for AUTH_IPV_AUTHORISATION_REQUESTED event to be warning

### DIFF
--- a/src/services/PostEventProcessor.ts
+++ b/src/services/PostEventProcessor.ts
@@ -84,9 +84,10 @@ export class PostEventProcessor {
 			switch (eventName) {
 				case Constants.AUTH_IPV_AUTHORISATION_REQUESTED: {
 					if (!this.checkIfValidString([userDetails.email, eventDetails.client_id, eventDetails.clientLandingPageUrl])) {
-						this.logger.error( { message: "Missing or invalid value for any or all of userDetails.email, eventDetails.client_id, eventDetails.clientLandingPageUrl fields required for AUTH_IPV_AUTHORISATION_REQUESTED event type" }, { messageCode: MessageCodes.MISSING_MANDATORY_FIELDS });
-						throw new AppError(HttpCodesEnum.SERVER_ERROR, `Missing info in sqs ${Constants.AUTH_IPV_AUTHORISATION_REQUESTED} event`);
+						this.logger.warn({ message: "Missing or invalid value for any or all of userDetails.email, eventDetails.client_id, eventDetails.clientLandingPageUrl fields required for AUTH_IPV_AUTHORISATION_REQUESTED event type" }, { messageCode: MessageCodes.MISSING_MANDATORY_FIELDS });
+						return `Missing info in sqs ${Constants.AUTH_IPV_AUTHORISATION_REQUESTED} event, it is unlikely that this event was meant for F2F`;
 					}
+
 					updateExpression = "SET ipvStartedOn = :ipvStartedOn, userEmail = :userEmail, clientName = :clientName,  redirectUri = :redirectUri, expiresOn = :expiresOn";
 					expressionAttributeValues = {
 						":userEmail": returnRecord.userEmail,
@@ -145,8 +146,8 @@ export class PostEventProcessor {
 			};
 
 		} catch (error: any) {
-			this.logger.error({ message: "Cannot parse event data" });
-			throw new AppError( HttpCodesEnum.BAD_REQUEST, "Cannot parse event data");
+			this.logger.error({ message: "Cannot parse event data", error });
+			throw new AppError(HttpCodesEnum.BAD_REQUEST, "Cannot parse event data");
 		}
 	}
 

--- a/src/tests/data/sqs-events.ts
+++ b/src/tests/data/sqs-events.ts
@@ -1,138 +1,138 @@
 import { ReturnSQSEvent } from "../../models/ReturnSQSEvent";
 
 export const VALID_GOV_NOTIFY_HANDLER_SQS_EVENT = {
-  "Records": [
-    {
-      "messageId": "6e67a34a-94f1-493f-b9eb-3d421aa701a8",
-      // pragma: allowlist nextline secret
-      "receiptHandle": "AQEBDzpW+TMqnd6I8zcqmrq8g8BTsuDjI745ci0bJ46g0Ej",
-      "body": "{\"Message\":{\"userId\":\"user_id\",\"emailAddress\":\"test.user@digital.cabinet-office.gov.uk\",\"firstName\":\"Frederick\",\"lastName\":\"Flintstone\",\"messageType\":\"email\"}}",
-      "attributes": {
-        "ApproximateReceiveCount": "1",
-        "SentTimestamp": "1588867971441",
-        "SenderId": "AIDAIVEA3AGEU7NF6DRAG",
-        "ApproximateFirstReceiveTimestamp": "1588867971443",
-      },
-      "messageAttributes": {},
-      // pragma: allowlist nextline secret
-      "md5OfBody": "ef38e4dfa52ade850f671b7e1915f26b",
-      "eventSource": "aws:sqs",
-      "eventSourceARN": "queue_arn",
-      "awsRegion": "eu-west-2",
-    },
-  ],
+	"Records": [
+		{
+			"messageId": "6e67a34a-94f1-493f-b9eb-3d421aa701a8",
+			// pragma: allowlist nextline secret
+			"receiptHandle": "AQEBDzpW+TMqnd6I8zcqmrq8g8BTsuDjI745ci0bJ46g0Ej",
+			"body": "{\"Message\":{\"userId\":\"user_id\",\"emailAddress\":\"test.user@digital.cabinet-office.gov.uk\",\"firstName\":\"Frederick\",\"lastName\":\"Flintstone\",\"messageType\":\"email\"}}",
+			"attributes": {
+				"ApproximateReceiveCount": "1",
+				"SentTimestamp": "1588867971441",
+				"SenderId": "AIDAIVEA3AGEU7NF6DRAG",
+				"ApproximateFirstReceiveTimestamp": "1588867971443",
+			},
+			"messageAttributes": {},
+			// pragma: allowlist nextline secret
+			"md5OfBody": "ef38e4dfa52ade850f671b7e1915f26b",
+			"eventSource": "aws:sqs",
+			"eventSourceARN": "queue_arn",
+			"awsRegion": "eu-west-2",
+		},
+	],
 };
 
 export const VALID_AUTH_IPV_AUTHORISATION_REQUESTED_TXMA_EVENT: ReturnSQSEvent = {
-  event_id: "588f4a66-f75a-4728-9f7b-8afd865c233c",
-  client_id: "ekwU",
-  clientLandingPageUrl: "REDIRECT_URL",
-  event_name: "AUTH_IPV_AUTHORISATION_REQUESTED",
-  // rp_name: "replay",
-  timestamp: 1681902001,
-  timestamp_formatted: "2023-04-19T11:00:01.000Z",
-  user: {
-    user_id: "01333e01-dde3-412f-a484-5555",
-    email: "jest@test.com"
-  }
+	event_id: "588f4a66-f75a-4728-9f7b-8afd865c233c",
+	client_id: "ekwU",
+	clientLandingPageUrl: "REDIRECT_URL",
+	event_name: "AUTH_IPV_AUTHORISATION_REQUESTED",
+	// rp_name: "replay",
+	timestamp: 1681902001,
+	timestamp_formatted: "2023-04-19T11:00:01.000Z",
+	user: {
+		user_id: "01333e01-dde3-412f-a484-5555",
+		email: "jest@test.com",
+	},
 };
 
 export const VALID_AUTH_IPV_AUTHORISATION_REQUESTED_TXMA_EVENT_STRING = JSON.stringify(VALID_AUTH_IPV_AUTHORISATION_REQUESTED_TXMA_EVENT);
 
 export const VALID_AUTH_IPV_AUTHORISATION_REQUESTED_SQS_EVENT = {
-  "Records": [
-    {
-      "messageId": "6e67a34a-94f1-493f-b9eb-3d421aa701a8",
-      // pragma: allowlist nextline secret
-      "receiptHandle": "AQEBDzpW+TMqnd6I8zcqmrq8g8BTsuDjI745ci0bJ46g0Ej",
-      "body": VALID_AUTH_IPV_AUTHORISATION_REQUESTED_TXMA_EVENT_STRING,
-      "attributes": {
-        "ApproximateReceiveCount": "1",
-        "SentTimestamp": "1588867971441",
-        "SenderId": "AIDAIVEA3AGEU7NF6DRAG",
-        "ApproximateFirstReceiveTimestamp": "1588867971443",
-      },
-      "messageAttributes": {},
-      // pragma: allowlist nextline secret
-      "md5OfBody": "ef38e4dfa52ade850f671b7e1915f26b",
-      "eventSource": "aws:sqs",
-      "eventSourceARN": "queue_arn",
-      "awsRegion": "eu-west-2",
-    },
-  ],
+	"Records": [
+		{
+			"messageId": "6e67a34a-94f1-493f-b9eb-3d421aa701a8",
+			// pragma: allowlist nextline secret
+			"receiptHandle": "AQEBDzpW+TMqnd6I8zcqmrq8g8BTsuDjI745ci0bJ46g0Ej",
+			"body": VALID_AUTH_IPV_AUTHORISATION_REQUESTED_TXMA_EVENT_STRING,
+			"attributes": {
+				"ApproximateReceiveCount": "1",
+				"SentTimestamp": "1588867971441",
+				"SenderId": "AIDAIVEA3AGEU7NF6DRAG",
+				"ApproximateFirstReceiveTimestamp": "1588867971443",
+			},
+			"messageAttributes": {},
+			// pragma: allowlist nextline secret
+			"md5OfBody": "ef38e4dfa52ade850f671b7e1915f26b",
+			"eventSource": "aws:sqs",
+			"eventSourceARN": "queue_arn",
+			"awsRegion": "eu-west-2",
+		},
+	],
 };
 
 export const VALID_F2F_YOTI_START_TXMA_EVENT: ReturnSQSEvent = {
-  "event_id": "588f4a66-f75a-4728-9f7b-8afd865c233d",
-  "client_id": "ekwU",
-  "event_name": "F2F_YOTI_START",
-  "timestamp": 1681902001,
-  "timestamp_formatted": "2023-04-19T11:00:01.000Z",
-  "user": {
-    "user_id": "01333e01-dde3-412f-a484-4444",
-    "email": "jest@test.com"
-  }
+	"event_id": "588f4a66-f75a-4728-9f7b-8afd865c233d",
+	"client_id": "ekwU",
+	"event_name": "F2F_YOTI_START",
+	"timestamp": 1681902001,
+	"timestamp_formatted": "2023-04-19T11:00:01.000Z",
+	"user": {
+		"user_id": "01333e01-dde3-412f-a484-4444",
+		"email": "jest@test.com",
+	},
 };
 
 export const VALID_F2F_YOTI_START_TXMA_EVENT_STRING = JSON.stringify(VALID_F2F_YOTI_START_TXMA_EVENT);
 
 export const VALID_IPV_F2F_CRI_VC_CONSUMED_TXMA_EVENT: ReturnSQSEvent = {
-  "event_id": "588f4a66-f75a-4728-9f7b-8afd865c233e",
-  "client_id": "ekwU",
-  "event_name": "IPV_F2F_CRI_VC_CONSUMED",
-  "clientLandingPageUrl": "REDIRECT_URL",
-  "timestamp": 1681902001,
-  "timestamp_formatted": "2023-04-19T11:00:01.000Z",
-  "user": {
-    "user_id": "01333e01-dde3-412f-a484-4444",
-    // pragma: allowlist nextline secret
-    "email": "e914e32172adcdad6c0906f7e5a0f4f43a6e99847c4370df783c7142f71ba454"
-  },
-  "restricted": {
-    "nameParts": [
-      {
-        "type": "GivenName",
-        "value": "ANGELA"
-      },
-      {
-        "type": "GivenName",
-        "value": "ZOE"
-      },
-      {
-        "type": "FamilyName",
-        "value": "UK SPECIMEN"
-      }
-    ]
-  }
+	"event_id": "588f4a66-f75a-4728-9f7b-8afd865c233e",
+	"client_id": "ekwU",
+	"event_name": "IPV_F2F_CRI_VC_CONSUMED",
+	"clientLandingPageUrl": "REDIRECT_URL",
+	"timestamp": 1681902001,
+	"timestamp_formatted": "2023-04-19T11:00:01.000Z",
+	"user": {
+		"user_id": "01333e01-dde3-412f-a484-4444",
+		// pragma: allowlist nextline secret
+		"email": "e914e32172adcdad6c0906f7e5a0f4f43a6e99847c4370df783c7142f71ba454",
+	},
+	"restricted": {
+		"nameParts": [
+			{
+				"type": "GivenName",
+				"value": "ANGELA",
+			},
+			{
+				"type": "GivenName",
+				"value": "ZOE",
+			},
+			{
+				"type": "FamilyName",
+				"value": "UK SPECIMEN",
+			},
+		],
+	},
 };
 
 export const VALID_IPV_F2F_CRI_VC_CONSUMED_TXMA_EVENT_STRING = JSON.stringify(VALID_IPV_F2F_CRI_VC_CONSUMED_TXMA_EVENT);
 
 export const VALID_AUTH_DELETE_ACCOUNT_TXMA_EVENT = {
-  event_id: "588f4a66-f75a-4728-9f7b-8afd865c233f",
-  client_id: "ekwU",
-  component_id: "UNKNOWN",
-  event_name: "AUTH_DELETE_ACCOUNT",
-  redirect_uri: "www.localhost.com",
-  timestamp: 1681902001,
-  timestamp_formatted: "2023-04-19T11:00:01.000Z",
-  user: {
-    user_id: "01333e01-dde3-412f-a484-3333",
-    // pragma: allowlist nextline secret
-    email: "e914e32172adcdad6c0906f7e5a0f4f43a6e99847c4370df783c7142f71ba454"
-  }
+	event_id: "588f4a66-f75a-4728-9f7b-8afd865c233f",
+	client_id: "ekwU",
+	component_id: "UNKNOWN",
+	event_name: "AUTH_DELETE_ACCOUNT",
+	redirect_uri: "www.localhost.com",
+	timestamp: 1681902001,
+	timestamp_formatted: "2023-04-19T11:00:01.000Z",
+	user: {
+		user_id: "01333e01-dde3-412f-a484-3333",
+		// pragma: allowlist nextline secret
+		email: "e914e32172adcdad6c0906f7e5a0f4f43a6e99847c4370df783c7142f71ba454",
+	},
 };
 
 export const VALID_AUTH_DELETE_ACCOUNT_TXMA_EVENT_STRING = JSON.stringify(VALID_AUTH_DELETE_ACCOUNT_TXMA_EVENT);
 
 
 export const VALID_GOV_NOTIFY_SQS_TXMA_EVENT = {
-  Message: {
-    emailAddress: "jest@test.com",
-    firstName: "Test",
-    lastName: "User",
-    messageType: "email"
-  }
+	Message: {
+		emailAddress: "jest@test.com",
+		firstName: "Test",
+		lastName: "User",
+		messageType: "email",
+	},
 };
 
 export const VALID_GOV_NOTIFY_SQS_TXMA_EVENTT_STRING = JSON.stringify(VALID_GOV_NOTIFY_SQS_TXMA_EVENT);

--- a/src/tests/unit/services/PostEventProcessor.test.ts
+++ b/src/tests/unit/services/PostEventProcessor.test.ts
@@ -1,11 +1,15 @@
+/* eslint-disable @typescript-eslint/unbound-method */
 import { Metrics } from "@aws-lambda-powertools/metrics";
 import { Logger } from "@aws-lambda-powertools/logger";
 import { PostEventProcessor } from "../../../services/PostEventProcessor";
 import { mock } from "jest-mock-extended";
 import { IPRService } from "../../../services/IPRService";
 import { HttpCodesEnum } from "../../../models/enums/HttpCodesEnum";
+import { MessageCodes } from "../../../models/enums/MessageCodes";
+import { ReturnSQSEvent } from "../../../models/ReturnSQSEvent";
 import { absoluteTimeNow } from "../../../utils/DateTimeUtils";
 import { AppError } from "../../../utils/AppError";
+import { Constants } from "../../../utils/Constants";
 import {
 	VALID_AUTH_DELETE_ACCOUNT_TXMA_EVENT_STRING,
 	VALID_AUTH_IPV_AUTHORISATION_REQUESTED_TXMA_EVENT_STRING,
@@ -33,52 +37,16 @@ describe("PostEventProcessor", () => {
 		expect(response.eventBody).toBe("OK");
 	});
 
-	it("Calls saveEventData with appropriate payload for AUTH_IPV_AUTHORISATION_REQUESTED event", async () => {
-		await postEventProcessor.processRequest(VALID_AUTH_IPV_AUTHORISATION_REQUESTED_TXMA_EVENT_STRING);
-		const expiresOn = absoluteTimeNow() + Number(process.env.SESSION_RETURN_RECORD_TTL!);
-		// eslint-disable-next-line @typescript-eslint/unbound-method
-		expect(mockIprService.saveEventData).toHaveBeenCalledWith("01333e01-dde3-412f-a484-5555", "SET ipvStartedOn = :ipvStartedOn, userEmail = :userEmail, clientName = :clientName,  redirectUri = :redirectUri, expiresOn = :expiresOn", { ":clientName": "ekwU", ":ipvStartedOn": 1681902001, ":redirectUri": "REDIRECT_URL", ":userEmail": "jest@test.com", ":expiresOn": expiresOn });
-	});
-
-	it("Calls saveEventData with appropriate payload for F2F_YOTI_START_EVENT event", async () => {
-		await postEventProcessor.processRequest(VALID_F2F_YOTI_START_TXMA_EVENT_STRING);
-		// eslint-disable-next-line @typescript-eslint/unbound-method
-		expect(mockIprService.saveEventData).toHaveBeenCalledWith("01333e01-dde3-412f-a484-4444", "SET journeyWentAsyncOn = :journeyWentAsyncOn", { ":journeyWentAsyncOn": 1681902001 });
-	});
-
-	it("Calls saveEventData with appropriate payload for IPV_F2F_CRI_VC_CONSUMED_EVENT event", async () => {
-		await postEventProcessor.processRequest(VALID_IPV_F2F_CRI_VC_CONSUMED_TXMA_EVENT_STRING);
-		// eslint-disable-next-line @typescript-eslint/unbound-method
-		expect(mockIprService.saveEventData).toHaveBeenCalledWith("01333e01-dde3-412f-a484-4444", "SET readyToResumeOn = :readyToResumeOn, nameParts = :nameParts", { ":readyToResumeOn": 1681902001, ":nameParts": [{ "type": "GivenName", "value": "ANGELA" }, { "type": "GivenName", "value": "ZOE" }, { "type":"FamilyName", "value":"UK SPECIMEN" }] });
-	});
-
-	it("Calls saveEventData with appropriate payload for AUTH_DELETE_ACCOUNT_EVENT event", async () => {
-		await postEventProcessor.processRequest(VALID_AUTH_DELETE_ACCOUNT_TXMA_EVENT_STRING);
-		// eslint-disable-next-line @typescript-eslint/unbound-method
-		expect(mockIprService.saveEventData).toHaveBeenCalledWith("01333e01-dde3-412f-a484-3333", "SET accountDeletedOn = :accountDeletedOn, userEmail = :userEmail, nameParts = :nameParts, clientName = :clientName,  redirectUri = :redirectUri", { ":accountDeletedOn": 1681902001, ":clientName": "", ":nameParts": [], ":redirectUri": "", ":userEmail": "" });
-	});
-
-	it("Throws error if clientLandingPageUrl is missing", async () => {
-		const AUTH_IPV_AUTHORISATION_REQUESTED_EVENT_MISSING_LANDINGURL = "{\n\t\"event_id\":\"588f4a66-f75a-4728-9f7b-8afd865c233c\",\n\t\"client_id\":\"ekwU\",\n\t\"event_name\":\"AUTH_IPV_AUTHORISATION_REQUESTED\",\n\t\"redirect_uri\":\"www.localhost.com\",\n\t\"rp_name\":\"replay\",\n\t\"timestamp\":\"1681902001\",\n\t\"timestamp_formatted\":\"2023-04-19T11:00:01.000Z\",\n\t\"user\":{\n\t\t \"user_id\":\"01333e01-dde3-412f-a484-5555\",\n\t\t \"email\":\"jest@test.com\"\n\t}\n}";
-		await expect(postEventProcessor.processRequest(AUTH_IPV_AUTHORISATION_REQUESTED_EVENT_MISSING_LANDINGURL)).rejects.toThrow(
-			new AppError(HttpCodesEnum.SERVER_ERROR, "Cannot parse event data"),
-		);
-
-		expect(mockLogger.error).toHaveBeenNthCalledWith(1, { "message":"Missing or invalid value for any or all of userDetails.email, eventDetails.client_id, eventDetails.clientLandingPageUrl fields required for AUTH_IPV_AUTHORISATION_REQUESTED event type" }, { "messageCode": "MISSING_MANDATORY_FIELDS_IN_SQS_EVENT" });
-	});
-
-	it("Throws error if clientLandingPageUrl has spaces", async () => {
-		const AUTH_IPV_AUTHORISATION_REQUESTED_EVENT_URL_SPACES = "{\n\t\"event_id\":\"588f4a66-f75a-4728-9f7b-8afd865c233c\",\n\t\"client_id\":\"ekwU\",\n\t\"event_name\":\"AUTH_IPV_AUTHORISATION_REQUESTED\",\n\t\"clientLandingPageUrl\":\"   \",\n\t\"timestamp\":\"1681902001\",\n\t\"timestamp_formatted\":\"2023-04-19T11:00:01.000Z\",\n\t\"user\":{\n\t\t \"user_id\":\"01333e01-dde3-412f-a484-5555\",\n\t\t \"email\":\"jest@test.com\"\n\t}\n}";
-		await expect(postEventProcessor.processRequest(AUTH_IPV_AUTHORISATION_REQUESTED_EVENT_URL_SPACES)).rejects.toThrow(
-			new AppError(HttpCodesEnum.SERVER_ERROR, "Cannot parse event data"),
-		);
-
-		expect(mockLogger.error).toHaveBeenNthCalledWith(1, { "message":"Missing or invalid value for any or all of userDetails.email, eventDetails.client_id, eventDetails.clientLandingPageUrl fields required for AUTH_IPV_AUTHORISATION_REQUESTED event type" }, { "messageCode": "MISSING_MANDATORY_FIELDS_IN_SQS_EVENT" });
-	});
-
 	it("Throws error if user object is missing", async () => {
-		const AUTH_IPV_AUTHORISATION_REQUESTED_EVENT_USER_MISSING = "{\n\t\"event_id\":\"588f4a66-f75a-4728-9f7b-8afd865c233c\",\n\t\"client_id\":\"ekwU\",\n\t\"event_name\":\"AUTH_IPV_AUTHORISATION_REQUESTED\",\n\t\"clientLandingPageUrl\":\"www.localhost.com\",\n\t\"timestamp\":\"1681902001\",\n\t\"timestamp_formatted\":\"2023-04-19T11:00:01.000Z\"\n}";
-		await expect(postEventProcessor.processRequest(AUTH_IPV_AUTHORISATION_REQUESTED_EVENT_USER_MISSING)).rejects.toThrow(
+		const AUTH_IPV_AUTHORISATION_REQUESTED_EVENT_USER_MISSING = {
+			event_id: "588f4a66-f75a-4728-9f7b-8afd865c233c",
+			client_id: "ekwU",
+			clientLandingPageUrl: "REDIRECT_URL",
+			event_name: "AUTH_IPV_AUTHORISATION_REQUESTED",
+			timestamp: 1681902001,
+			timestamp_formatted: "2023-04-19T11:00:01.000Z",
+		};
+		await expect(postEventProcessor.processRequest(JSON.stringify(AUTH_IPV_AUTHORISATION_REQUESTED_EVENT_USER_MISSING))).rejects.toThrow(
 			new AppError(HttpCodesEnum.SERVER_ERROR, "Cannot parse event data"),
 		);
 		expect(mockLogger.error).toHaveBeenNthCalledWith(1, { "message": "Missing user details in the incoming SQS event" }, { "messageCode": "MISSING_MANDATORY_FIELDS_IN_SQS_EVENT" });
@@ -86,37 +54,155 @@ describe("PostEventProcessor", () => {
 	});
 
 	it("Throws error if eventName is missing", async () => {
-		const AUTH_IPV_AUTHORISATION_REQUESTED_EVENT_NAME_MISSING = "{\n\t\"event_id\":\"588f4a66-f75a-4728-9f7b-8afd865c233c\",\n\t\"client_id\":\"ekwU\",\n\t\"redirect_uri\":\"www.localhost.com\",\n\t\"timestamp\":\"1681902001\",\n\t\"timestamp_formatted\":\"2023-04-19T11:00:01.000Z\",\n\t\"user\":{\n\t\t \"user_id\":\"01333e01-dde3-412f-a484-5555\",\n\t\t \"email\":\"jest@test.com\"\n\t}\n}";
-		await expect(postEventProcessor.processRequest(AUTH_IPV_AUTHORISATION_REQUESTED_EVENT_NAME_MISSING)).rejects.toThrow(
+		const AUTH_IPV_AUTHORISATION_REQUESTED_EVENT_NAME_MISSING = {
+			event_id: "588f4a66-f75a-4728-9f7b-8afd865c233c",
+			client_id: "ekwU",
+			clientLandingPageUrl: "REDIRECT_URL",
+			timestamp: 1681902001,
+			timestamp_formatted: "2023-04-19T11:00:01.000Z",
+			user: {
+				user_id: "01333e01-dde3-412f-a484-5555",
+				email: "jest@test.com",
+			},
+		};
+		await expect(postEventProcessor.processRequest(JSON.stringify(AUTH_IPV_AUTHORISATION_REQUESTED_EVENT_NAME_MISSING))).rejects.toThrow(
 			new AppError(HttpCodesEnum.SERVER_ERROR, "Cannot parse event data"),
 		);
 		expect(mockLogger.error).toHaveBeenNthCalledWith(1, { "message": "Missing or invalid value for any or all of event name, timestamp in the incoming SQS event" }, { "messageCode": "MISSING_MANDATORY_FIELDS_IN_SQS_EVENT" });
 	});
 
-	it("Throws error if eventName has spaces", async () => {
-		const AUTH_IPV_AUTHORISATION_REQUESTED_EVENT_NAME_SPACES = "{\n\t\"event_id\":\"588f4a66-f75a-4728-9f7b-8afd865c233c\",\n\t\"client_id\":\"ekwU\",\n\t\"event_name\":\"  \",\n\t\"redirect_uri\":\"www.localhost.com\",\n\t\"rp_name\":\"replay\",\n\t\"timestamp\":\"1681902001\",\n\t\"timestamp_formatted\":\"2023-04-19T11:00:01.000Z\",\n\t\"user\":{\n\t\t \"user_id\":\"01333e01-dde3-412f-a484-5555\",\n\t\t \"email\":\"jest@test.com\"\n\t}\n}";
-		await expect(postEventProcessor.processRequest(AUTH_IPV_AUTHORISATION_REQUESTED_EVENT_NAME_SPACES)).rejects.toThrow(
+	it("Throws error if eventName is only spaces", async () => {
+		const AUTH_IPV_AUTHORISATION_REQUESTED_EVENT_NAME_SPACES = {
+			event_id: "588f4a66-f75a-4728-9f7b-8afd865c233c",
+			client_id: "ekwU",
+			eventName: "  ",
+			clientLandingPageUrl: "REDIRECT_URL",
+			timestamp: 1681902001,
+			timestamp_formatted: "2023-04-19T11:00:01.000Z",
+			user: {
+				user_id: "01333e01-dde3-412f-a484-5555",
+				email: "jest@test.com",
+			},
+		};
+		await expect(postEventProcessor.processRequest(JSON.stringify(AUTH_IPV_AUTHORISATION_REQUESTED_EVENT_NAME_SPACES))).rejects.toThrow(
 			new AppError(HttpCodesEnum.SERVER_ERROR, "Cannot parse event data"),
 		);
 		expect(mockLogger.error).toHaveBeenNthCalledWith(1, { "message": "Missing or invalid value for any or all of event name, timestamp in the incoming SQS event" }, { "messageCode": "MISSING_MANDATORY_FIELDS_IN_SQS_EVENT" });
 	});
 
 	it("Throws error if timestamp is missing", async () => {
-		const AUTH_IPV_AUTHORISATION_REQUESTED_EVENT_TIMESTAMP_MISSING = "{\n\t\"event_id\":\"588f4a66-f75a-4728-9f7b-8afd865c233c\",\n\t\"client_id\":\"ekwU\",\n\t\"event_name\":\"AUTH_IPV_AUTHORISATION_REQUESTED\",\n\t\"clientLandingPageUrl\":\"www.localhost.com\",\n\t\"timestamp_formatted\":\"2023-04-19T11:00:01.000Z\",\n\t\"user\":{\n\t\t \"user_id\":\"01333e01-dde3-412f-a484-5555\",\n\t\t \"email\":\"jest@test.com\"\n\t}\n}";
-		await expect(postEventProcessor.processRequest(AUTH_IPV_AUTHORISATION_REQUESTED_EVENT_TIMESTAMP_MISSING)).rejects.toThrow(
+		const AUTH_IPV_AUTHORISATION_REQUESTED_EVENT_TIMESTAMP_MISSING = {
+			event_id: "588f4a66-f75a-4728-9f7b-8afd865c233c",
+			client_id: "ekwU",
+			clientLandingPageUrl: "REDIRECT_URL",
+			event_name: "AUTH_IPV_AUTHORISATION_REQUESTED",
+			timestamp_formatted: "2023-04-19T11:00:01.000Z",
+			user: {
+				user_id: "01333e01-dde3-412f-a484-5555",
+				email: "jest@test.com",
+			},
+		};
+		await expect(postEventProcessor.processRequest(JSON.stringify(AUTH_IPV_AUTHORISATION_REQUESTED_EVENT_TIMESTAMP_MISSING))).rejects.toThrow(
 			new AppError(HttpCodesEnum.SERVER_ERROR, "Cannot parse event data"),
 		);
 
 		expect(mockLogger.error).toHaveBeenNthCalledWith(1, { "message":"Missing or invalid value for any or all of event name, timestamp in the incoming SQS event" }, { "messageCode": "MISSING_MANDATORY_FIELDS_IN_SQS_EVENT" });
 	});
 
-	it("Throws error if restricted is missing", async () => {
-		const IPV_F2F_CRI_VC_CONSUMED_EVENT_INVALID = "{\"event_id\":\"588f4a66-f75a-4728-9f7b-8afd865c233e\",\"client_id\":\"ekwU\",\"component_id\":\"UNKNOWN\",\"event_name\":\"IPV_F2F_CRI_VC_CONSUMED\",\"redirect_uri\":\"www.localhost.com\",\"rp_name\":\"replay\",\"timestamp\":1681902001,\"timestamp_formatted\":\"2023-04-19T11:00:01.000Z\",\"user\":{\"user_id\":\"01333e01-dde3-412f-a484-4444\",\"email\":\"e914e32172adcdad6c0906f7e5a0f4f43a6e99847c4370df783c7142f71ba454\"}}";
-		await expect(postEventProcessor.processRequest(IPV_F2F_CRI_VC_CONSUMED_EVENT_INVALID)).rejects.toThrow(
-			new AppError(HttpCodesEnum.SERVER_ERROR, "Cannot parse event data"),
-		);
+	describe("AUTH_IPV_AUTHORISATION_REQUESTED event", () => {
+		it("Calls saveEventData with appropriate payload for AUTH_IPV_AUTHORISATION_REQUESTED event", async () => {
+			await postEventProcessor.processRequest(VALID_AUTH_IPV_AUTHORISATION_REQUESTED_TXMA_EVENT_STRING);
+			const expiresOn = absoluteTimeNow() + Number(process.env.SESSION_RETURN_RECORD_TTL!);
+			expect(mockIprService.saveEventData).toHaveBeenCalledWith("01333e01-dde3-412f-a484-5555", "SET ipvStartedOn = :ipvStartedOn, userEmail = :userEmail, clientName = :clientName,  redirectUri = :redirectUri, expiresOn = :expiresOn", { ":clientName": "ekwU", ":ipvStartedOn": 1681902001, ":redirectUri": "REDIRECT_URL", ":userEmail": "jest@test.com", ":expiresOn": expiresOn });
+		});
+	
+		it("Logs a warning if user.email is missing", async () => {
+			const AUTH_IPV_AUTHORISATION_REQUESTED_EVENT_MISSING_EMAIL: ReturnSQSEvent = {
+				event_id: "588f4a66-f75a-4728-9f7b-8afd865c233c",
+				client_id: "ekwU",
+				clientLandingPageUrl: "REDIRECT_URL",
+				event_name: "AUTH_IPV_AUTHORISATION_REQUESTED",
+				timestamp: 1681902001,
+				timestamp_formatted: "2023-04-19T11:00:01.000Z",
+				user: {
+					user_id: "01333e01-dde3-412f-a484-5555",
+				},
+			};
+			const result = await postEventProcessor.processRequest(JSON.stringify(AUTH_IPV_AUTHORISATION_REQUESTED_EVENT_MISSING_EMAIL));
+			expect(mockLogger.warn).toHaveBeenCalledWith({ message: "Missing or invalid value for any or all of userDetails.email, eventDetails.client_id, eventDetails.clientLandingPageUrl fields required for AUTH_IPV_AUTHORISATION_REQUESTED event type" }, { messageCode: MessageCodes.MISSING_MANDATORY_FIELDS });
+			expect(result).toBe(`Missing info in sqs ${Constants.AUTH_IPV_AUTHORISATION_REQUESTED} event, it is unlikely that this event was meant for F2F`);
+		});
 
-		expect(mockLogger.error).toHaveBeenNthCalledWith(1, { "message":"Missing nameParts fields required for IPV_F2F_CRI_VC_CONSUMED event type" }, { "messageCode": "MISSING_MANDATORY_FIELDS_IN_SQS_EVENT" });
+		it("Throws error if clientLandingPageUrl is missing", async () => {
+			const AUTH_IPV_AUTHORISATION_REQUESTED_EVENT_MISSING_LANDINGURL: ReturnSQSEvent = {
+				event_id: "588f4a66-f75a-4728-9f7b-8afd865c233c",
+				client_id: "ekwU",
+				event_name: "AUTH_IPV_AUTHORISATION_REQUESTED",
+				timestamp: 1681902001,
+				timestamp_formatted: "2023-04-19T11:00:01.000Z",
+				user: {
+					user_id: "01333e01-dde3-412f-a484-5555",
+					email: "test@jest.com",
+				},
+			};
+			const result = await postEventProcessor.processRequest(JSON.stringify(AUTH_IPV_AUTHORISATION_REQUESTED_EVENT_MISSING_LANDINGURL));
+			expect(mockLogger.warn).toHaveBeenCalledWith({ message: "Missing or invalid value for any or all of userDetails.email, eventDetails.client_id, eventDetails.clientLandingPageUrl fields required for AUTH_IPV_AUTHORISATION_REQUESTED event type" }, { messageCode: MessageCodes.MISSING_MANDATORY_FIELDS });
+			expect(result).toBe(`Missing info in sqs ${Constants.AUTH_IPV_AUTHORISATION_REQUESTED} event, it is unlikely that this event was meant for F2F`);
+		});
+	
+		it("Throws error if clientLandingPageUrl is only spaces", async () => {
+			const AUTH_IPV_AUTHORISATION_REQUESTED_EVENT_URL_SPACES: ReturnSQSEvent = {
+				event_id: "588f4a66-f75a-4728-9f7b-8afd865c233c",
+				client_id: "ekwU",
+				clientLandingPageUrl: "  ",
+				event_name: "AUTH_IPV_AUTHORISATION_REQUESTED",
+				timestamp: 1681902001,
+				timestamp_formatted: "2023-04-19T11:00:01.000Z",
+				user: {
+					user_id: "01333e01-dde3-412f-a484-5555",
+					email: "test@jest.com",
+				},
+			};
+			const result = await postEventProcessor.processRequest(JSON.stringify(AUTH_IPV_AUTHORISATION_REQUESTED_EVENT_URL_SPACES));
+			expect(mockLogger.warn).toHaveBeenCalledWith({ message: "Missing or invalid value for any or all of userDetails.email, eventDetails.client_id, eventDetails.clientLandingPageUrl fields required for AUTH_IPV_AUTHORISATION_REQUESTED event type" }, { messageCode: MessageCodes.MISSING_MANDATORY_FIELDS });
+			expect(result).toBe(`Missing info in sqs ${Constants.AUTH_IPV_AUTHORISATION_REQUESTED} event, it is unlikely that this event was meant for F2F`);
+		});
 	});
 
+	describe("IPV_F2F_CRI_VC_CONSUMED_EVENT event", () => {
+		it("Calls saveEventData with appropriate payload for IPV_F2F_CRI_VC_CONSUMED_EVENT event", async () => {
+			await postEventProcessor.processRequest(VALID_IPV_F2F_CRI_VC_CONSUMED_TXMA_EVENT_STRING);
+			expect(mockIprService.saveEventData).toHaveBeenCalledWith("01333e01-dde3-412f-a484-4444", "SET readyToResumeOn = :readyToResumeOn, nameParts = :nameParts", { ":readyToResumeOn": 1681902001, ":nameParts": [{ "type": "GivenName", "value": "ANGELA" }, { "type": "GivenName", "value": "ZOE" }, { "type":"FamilyName", "value":"UK SPECIMEN" }] });
+		});
+
+		it("Throws error if restricted is missing", async () => {
+			const IPV_F2F_CRI_VC_CONSUMED_EVENT_INVALID = {
+				event_id: "588f4a66-f75a-4728-9f7b-8afd865c233e",
+				client_id: "ekwU",
+				event_name: "IPV_F2F_CRI_VC_CONSUMED",
+				clientLandingPageUrl: "REDIRECT_URL",
+				timestamp: 1681902001,
+				timestamp_formatted: "2023-04-19T11:00:01.000Z",
+				user: {
+					user_id: "01333e01-dde3-412f-a484-4444",
+					// pragma: allowlist nextline secret
+					email: "e914e32172adcdad6c0906f7e5a0f4f43a6e99847c4370df783c7142f71ba454",
+				},
+			};
+			await expect(postEventProcessor.processRequest(JSON.stringify(IPV_F2F_CRI_VC_CONSUMED_EVENT_INVALID))).rejects.toThrow(
+				new AppError(HttpCodesEnum.SERVER_ERROR, "Cannot parse event data"),
+			);
+			expect(mockLogger.error).toHaveBeenNthCalledWith(1, { "message":"Missing nameParts fields required for IPV_F2F_CRI_VC_CONSUMED event type" }, { "messageCode": "MISSING_MANDATORY_FIELDS_IN_SQS_EVENT" });
+		});
+	});
+
+	it("Calls saveEventData with appropriate payload for F2F_YOTI_START_EVENT event", async () => {
+		await postEventProcessor.processRequest(VALID_F2F_YOTI_START_TXMA_EVENT_STRING);
+		expect(mockIprService.saveEventData).toHaveBeenCalledWith("01333e01-dde3-412f-a484-4444", "SET journeyWentAsyncOn = :journeyWentAsyncOn", { ":journeyWentAsyncOn": 1681902001 });
+	});
+
+	it("Calls saveEventData with appropriate payload for AUTH_DELETE_ACCOUNT_EVENT event", async () => {
+		await postEventProcessor.processRequest(VALID_AUTH_DELETE_ACCOUNT_TXMA_EVENT_STRING);
+		expect(mockIprService.saveEventData).toHaveBeenCalledWith("01333e01-dde3-412f-a484-3333", "SET accountDeletedOn = :accountDeletedOn, userEmail = :userEmail, nameParts = :nameParts, clientName = :clientName,  redirectUri = :redirectUri", { ":accountDeletedOn": 1681902001, ":clientName": "", ":nameParts": [], ":redirectUri": "", ":userEmail": "" });
+	});
 });


### PR DESCRIPTION
## Proposed changes

### What changed

- Changes validation issues for `AUTH_IPV_AUTHORISATION_REQUESTED` event to be warning
- Updates tests to make them more manageable by using objects rather than JSON strings

### Why did it change

We are getting 100s of validation log errors in IPVR that are causing a lot of noise and making it difficult to debug. This change means that we no longer throw errors that come from incorrect `AUTH_IPV_AUTHORISATION_REQUESTED` as we are assuming that they are not meant for us

### Screenshots

Event missing email
![image](https://github.com/alphagov/di-ipvreturn-api/assets/40401118/e9cd37dd-2f28-4a53-9b92-efb68ee9ccc5)
![image](https://github.com/alphagov/di-ipvreturn-api/assets/40401118/f3f7f642-7061-4eb2-b31a-9ae9a68d64d4)

### Issue tracking
- [F2F-1001](https://govukverify.atlassian.net/browse/F2F-1001)

## Checklists

### PII logging

- [x] Verified that no PII data is being logged


[F2F-1001]: https://govukverify.atlassian.net/browse/F2F-1001?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ