### PR TITLE
[F2F-996] - StreamProcessor readyToResumeOn

### DIFF
--- a/src/StreamProcessorHandler.ts
+++ b/src/StreamProcessorHandler.ts
@@ -41,7 +41,7 @@ class StreamProcessorHandler implements LambdaInterface {
 					return { batchItemFailures:[] };
 				}
 			} catch (error) {
-				logger.error({ message: "An error has occurred when processing the session record ", error });
+				logger.info({ message: "An error has occurred when processing the session record ", error });
 				return { batchItemFailures:[] };
 			}
 		} else {


### PR DESCRIPTION
## Proposed changes

### What changed

Updated the logging level from ERROR to INFO for the StreamProcessor

![Screenshot 2023-08-14 at 14 47 32](https://github.com/alphagov/di-ipvreturn-api/assets/117986969/72e84422-e0a9-4562-bdc1-ba7d5cfbab7c)


### Why did it change

It was ERROR before

### Issue tracking

- [F2F-996](https://govukverify.atlassian.net/browse/F2F-996)

## Checklists

### PII logging

- [x] Verified that no PII data is being logged

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed


[F2F-996]: https://govukverify.atlassian.net/browse/F2F-996?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ