### PR TITLE
[F2F-1156] adds govuk_signin_journey_id to stream processor logs

### DIFF
--- a/src/services/SessionEventProcessor.ts
+++ b/src/services/SessionEventProcessor.ts
@@ -45,6 +45,8 @@ export class SessionEventProcessor {
 	async processRequest(sessionEvent: any): Promise<void> {
 		const sessionEventData: SessionEvent = SessionEvent.parseRequest(JSON.stringify(sessionEvent));
 
+		this.logger.appendKeys({ govuk_signin_journey_id: sessionEventData.clientSessionId });
+
 		// Validate the notified field is set to false
 		if (sessionEventData.notified) {
 			this.logger.warn("User is already notified for this session event.", { messageCode: MessageCodes.USER_ALREADY_NOTIFIED });


### PR DESCRIPTION
## Proposed changes

### What changed

adds `govuk_signin_journey_id` to stream processor logs

### Why did it change

To enable production debugging

### Screenshots 

![image](https://github.com/alphagov/di-ipvreturn-api/assets/40401118/50c9ed91-938d-4088-b90b-43eec9ce03fd)

### Issue tracking
- [F2F-1156](https://govukverify.atlassian.net/browse/F2F-1156)

## Checklists

### PII logging

- [X] Verified that no PII data is being logged

[F2F-1156]: https://govukverify.atlassian.net/browse/F2F-1156?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ