### PR TITLE
[F2F-1061]Update Post Event to store additional postoffice visit timing details from TXMA event

### DIFF
--- a/src/models/ReturnSQSEvent.ts
+++ b/src/models/ReturnSQSEvent.ts
@@ -1,6 +1,6 @@
-import { NamePart } from "./SessionReturnRecord";
+import { NamePart, PostOfficeVisitDetails } from "./SessionReturnRecord";
 
-export type EventType = "AUTH_IPV_AUTHORISATION_REQUESTED" | "F2F_YOTI_START" | "IPV_F2F_CRI_VC_CONSUMED" | "AUTH_DELETE_ACCOUNT";
+export type EventType = "AUTH_IPV_AUTHORISATION_REQUESTED" | "F2F_YOTI_START" | "IPV_F2F_CRI_VC_CONSUMED" | "AUTH_DELETE_ACCOUNT" | "F2F_DOCUMENT_UPLOADED";
 
 
 export interface ReturnSQSEvent {
@@ -17,6 +17,9 @@ export interface ReturnSQSEvent {
 	};
 	restricted?: {
 		nameParts: NamePart[];
+	};
+	extensions?: {
+		post_office_visit_details: PostOfficeVisitDetails[];
 	};
 }
 

--- a/src/models/ReturnSQSEvent.ts
+++ b/src/models/ReturnSQSEvent.ts
@@ -1,4 +1,4 @@
-import { NamePart, PostOfficeVisitDetails } from "./SessionReturnRecord";
+import { NamePart, PostOfficeVisitDetails, PostOfficeInfo, DocumentDetails } from "./SessionReturnRecord";
 
 export type EventType = "AUTH_IPV_AUTHORISATION_REQUESTED" | "F2F_YOTI_START" | "IPV_F2F_CRI_VC_CONSUMED" | "AUTH_DELETE_ACCOUNT" | "F2F_DOCUMENT_UPLOADED";
 
@@ -16,10 +16,13 @@ export interface ReturnSQSEvent {
 		email?: string;
 	};
 	restricted?: {
-		nameParts: NamePart[];
+		nameParts?: NamePart[];
+		document_details?: DocumentDetails[];
+		docExpiryDate?: string;
 	};
 	extensions?: {
-		post_office_visit_details: PostOfficeVisitDetails[];
+		post_office_visit_details?: PostOfficeVisitDetails[];
+		post_office_details?: PostOfficeInfo[];
 	};
 }
 

--- a/src/models/SessionReturnRecord.ts
+++ b/src/models/SessionReturnRecord.ts
@@ -1,10 +1,14 @@
 import { ReturnSQSEvent } from "./ReturnSQSEvent";
 import { Constants } from "../utils/Constants";
-import { Logger } from "@aws-lambda-powertools/logger";
 
 export interface NamePart {
 	type: string;
 	value: string;
+}
+
+export interface PostOfficeVisitDetails {
+	post_office_date_of_visit: string;
+	post_office_time_of_visit: number;
 }
 
 export class SessionReturnRecord {
@@ -32,6 +36,11 @@ export class SessionReturnRecord {
 				this.nameParts = data.restricted?.nameParts;
 				break;
 			}
+			case Constants.F2F_DOCUMENT_UPLOADED:{
+				this.documentUploadedOn = data.timestamp;
+				this.postOfficeVisitDetails = data.extensions?.post_office_visit_details;
+				break;
+			}
 			case Constants.AUTH_DELETE_ACCOUNT:{
 				this.accountDeletedOn = data.timestamp;
 				this.clientSessionId = "";
@@ -53,6 +62,8 @@ export class SessionReturnRecord {
 
     nameParts?: NamePart[];
 
+	postOfficeVisitDetails?: PostOfficeVisitDetails[];
+
     clientName?: string;
 
     redirectUri?: string;
@@ -62,6 +73,8 @@ export class SessionReturnRecord {
     journeyWentAsyncOn?: number;
 
     readyToResumeOn?: number;
+
+	documentUploadedOn?: number;
 
     accountDeletedOn?: number;
 

--- a/src/models/SessionReturnRecord.ts
+++ b/src/models/SessionReturnRecord.ts
@@ -11,6 +11,22 @@ export interface PostOfficeVisitDetails {
 	post_office_time_of_visit: number;
 }
 
+export interface PostOfficeInfo {
+	name?: string;
+	address: string;
+	post_code: string;
+	location: [
+		{
+			latitude: number;
+			longitude: number;
+		},
+	];
+}
+
+export interface DocumentDetails {
+	documentType?: string;
+}
+
 export class SessionReturnRecord {
 	constructor(data: ReturnSQSEvent, expiresOn: number) {
 		this.userId = data.user.user_id;
@@ -29,11 +45,16 @@ export class SessionReturnRecord {
 				if (data.user.govuk_signin_journey_id && (data.user.govuk_signin_journey_id).toLowerCase() !== "unknown") {
 					this.clientSessionId = data.user.govuk_signin_journey_id;
 				}
+				this.postOfficeInfo = data.extensions?.post_office_details;
+				data.restricted?.document_details?.map(doc => {
+					this.documentType = doc.documentType;
+				});
 				break;
 			}
 			case Constants.IPV_F2F_CRI_VC_CONSUMED:{
 				this.readyToResumeOn = data.timestamp;
 				this.nameParts = data.restricted?.nameParts;
+				this.documentExpiryDate = data.restricted?.docExpiryDate;
 				break;
 			}
 			case Constants.F2F_DOCUMENT_UPLOADED:{
@@ -64,6 +85,8 @@ export class SessionReturnRecord {
 
 	postOfficeVisitDetails?: PostOfficeVisitDetails[];
 
+	postOfficeInfo?: PostOfficeInfo[];
+
     clientName?: string;
 
     redirectUri?: string;
@@ -81,4 +104,8 @@ export class SessionReturnRecord {
     expiresDate?: number;
 
     clientSessionId?: string;
+
+	documentType?: string;
+
+	documentExpiryDate?: string;
 }

--- a/src/services/PostEventProcessor.ts
+++ b/src/services/PostEventProcessor.ts
@@ -113,6 +113,20 @@ export class PostEventProcessor {
 						":journeyWentAsyncOn": returnRecord.journeyWentAsyncOn,
 						":expiresOn": returnRecord.expiresDate,
 					};
+
+					if (returnRecord.postOfficeInfo) {
+						updateExpression += ", postOfficeInfo = :postOfficeInfo";
+						expressionAttributeValues[":postOfficeInfo"] = returnRecord.postOfficeInfo;
+					} else {
+						this.logger.info(`No post_office_details in ${eventName} event`);
+					}
+
+					if (returnRecord.documentType) {
+						updateExpression += ", documentType = :documentType";
+						expressionAttributeValues[":documentType"] = returnRecord.documentType;
+					} else {
+						this.logger.info(`No document_details in ${eventName} event`);
+					}
 					
 					if (returnRecord.clientSessionId) {
 						updateExpression += ", clientSessionId = :clientSessionId";
@@ -132,6 +146,13 @@ export class PostEventProcessor {
 						":readyToResumeOn": returnRecord.readyToResumeOn,
 						":nameParts": returnRecord.nameParts,
 					};
+
+					if (returnRecord.documentExpiryDate) {
+						updateExpression += ", documentExpiryDate = :documentExpiryDate";
+						expressionAttributeValues[":documentExpiryDate"] = returnRecord.documentExpiryDate;
+					} else {
+						this.logger.info(`No docExpiryDate in ${eventName} event`);
+					}
 					break;
 				}
 				case Constants.F2F_DOCUMENT_UPLOADED: {

--- a/src/services/PostEventProcessor.ts
+++ b/src/services/PostEventProcessor.ts
@@ -119,7 +119,7 @@ export class PostEventProcessor {
 						expressionAttributeValues[":clientSessionId"] = returnRecord.clientSessionId;
 					} else {
 						this.logger.info(`No govuk_signin_journey_id in ${eventName} event`);
-					};
+					}
 					break;
 				}
 				case Constants.IPV_F2F_CRI_VC_CONSUMED: {
@@ -131,6 +131,18 @@ export class PostEventProcessor {
 					expressionAttributeValues = {
 						":readyToResumeOn": returnRecord.readyToResumeOn,
 						":nameParts": returnRecord.nameParts,
+					};
+					break;
+				}
+				case Constants.F2F_DOCUMENT_UPLOADED: {
+					if (!eventDetails.extensions || !eventDetails.extensions.post_office_visit_details) {
+						this.logger.error( { message: "Missing post_office_visit_details fields required for F2F_DOCUMENT_UPLOADED event type" }, { messageCode: MessageCodes.MISSING_MANDATORY_FIELDS });
+						throw new AppError(HttpCodesEnum.SERVER_ERROR, `Missing info in sqs ${Constants.F2F_DOCUMENT_UPLOADED} event`);
+					}
+					updateExpression = "SET documentUploadedOn = :documentUploadedOn, postOfficeVisitDetails = :postOfficeVisitDetails";
+					expressionAttributeValues = {
+						":documentUploadedOn": returnRecord.documentUploadedOn,
+						":postOfficeVisitDetails": returnRecord.postOfficeVisitDetails,
 					};
 					break;
 				}

--- a/src/tests/data/sqs-events.ts
+++ b/src/tests/data/sqs-events.ts
@@ -108,6 +108,40 @@ export const VALID_IPV_F2F_CRI_VC_CONSUMED_TXMA_EVENT: ReturnSQSEvent = {
 
 export const VALID_IPV_F2F_CRI_VC_CONSUMED_TXMA_EVENT_STRING = JSON.stringify(VALID_IPV_F2F_CRI_VC_CONSUMED_TXMA_EVENT);
 
+export const VALID_IPV_F2F_CRI_VC_CONSUMED_WITH_DOC_EXPIRYDATE_TXMA_EVENT: ReturnSQSEvent = {
+	"event_id": "588f4a66-f75a-4728-9f7b-8afd865c233e",
+	"client_id": "ekwU",
+	"event_name": "IPV_F2F_CRI_VC_CONSUMED",
+	"clientLandingPageUrl": "REDIRECT_URL",
+	"timestamp": 1681902001,
+	"timestamp_formatted": "2023-04-19T11:00:01.000Z",
+	"user": {
+		"user_id": "01333e01-dde3-412f-a484-4444",
+		// pragma: allowlist nextline secret
+		"email": "e914e32172adcdad6c0906f7e5a0f4f43a6e99847c4370df783c7142f71ba454",
+	},
+	"restricted": {
+		"nameParts": [
+			{
+				"type": "GivenName",
+				"value": "ANGELA",
+			},
+			{
+				"type": "GivenName",
+				"value": "ZOE",
+			},
+			{
+				"type": "FamilyName",
+				"value": "UK SPECIMEN",
+			},
+		],
+		"docExpiryDate": "2030-01-01",
+	},
+};
+
+export const VALID_IPV_F2F_CRI_VC_CONSUMED_WITH_DOC_EXPIRYDATE_TXMA_EVENT_STRING = JSON.stringify(VALID_IPV_F2F_CRI_VC_CONSUMED_WITH_DOC_EXPIRYDATE_TXMA_EVENT);
+
+
 export const VALID_AUTH_DELETE_ACCOUNT_TXMA_EVENT = {
 	event_id: "588f4a66-f75a-4728-9f7b-8afd865c233f",
 	client_id: "ekwU",
@@ -152,6 +186,40 @@ export const VALID_F2F_DOCUMENT_UPLOADED_TXMA_EVENT: ReturnSQSEvent = {
 			{
 				"post_office_date_of_visit": "1985-01-25",
 				"post_office_time_of_visit": 1688477191,
+			},
+		],
+	},
+};
+
+export const VALID_F2F_YOTI_START_WITH_PO_DOC_DETAILS_TXMA_EVENT: ReturnSQSEvent = {
+	"event_id": "588f4a66-f75a-4728-9f7b-8afd865c233d",
+	"client_id": "ekwU",
+	"event_name": "F2F_YOTI_START",
+	"timestamp": 1681902001,
+	"timestamp_formatted": "2023-04-19T11:00:01.000Z",
+	"user": {
+		"user_id": "01333e01-dde3-412f-a484-4444",
+		"email": "jest@test.com",
+	},
+	"extensions": {
+		"post_office_details": [
+			{
+				"name": "Post Office Name",
+				"address": "1 The Street, Funkytown",
+				"location": [
+					{
+						"latitude": 0.34322,
+						"longitude": -42.48372,
+					},
+				],
+				"post_code": "N1 2AA",
+			},
+		],
+	},
+	"restricted": {
+		"document_details": [
+			{
+				"documentType": "PASSPORT",
 			},
 		],
 	},

--- a/src/tests/data/sqs-events.ts
+++ b/src/tests/data/sqs-events.ts
@@ -137,3 +137,22 @@ export const VALID_GOV_NOTIFY_SQS_TXMA_EVENT = {
 };
 
 export const VALID_GOV_NOTIFY_SQS_TXMA_EVENTT_STRING = JSON.stringify(VALID_GOV_NOTIFY_SQS_TXMA_EVENT);
+
+export const VALID_F2F_DOCUMENT_UPLOADED_TXMA_EVENT: ReturnSQSEvent = {
+	"event_id": "588f4a66-f75a-4728-9f7b-8afd865c233e",
+	"client_id": "ekwU",
+	"event_name": "F2F_DOCUMENT_UPLOADED",
+	"timestamp": 1681902001,
+	"timestamp_formatted": "2023-04-19T11:00:01.000Z",
+	"user": {
+		"user_id": "01333e01-dde3-412f-a484-4444",
+	},
+	"extensions": {
+		"post_office_visit_details": [
+			{
+				"post_office_date_of_visit": "1985-01-25",
+				"post_office_time_of_visit": 1688477191,
+			},
+		],
+	},
+};

--- a/src/utils/Constants.ts
+++ b/src/utils/Constants.ts
@@ -18,6 +18,8 @@ export class Constants {
 
     static readonly IPV_F2F_CRI_VC_CONSUMED = "IPV_F2F_CRI_VC_CONSUMED";
 
+    static readonly F2F_DOCUMENT_UPLOADED = "F2F_DOCUMENT_UPLOADED";
+
     static readonly AUTH_DELETE_ACCOUNT = "AUTH_DELETE_ACCOUNT";
 
     static readonly POSTEVENT_LOGGER_SVC_NAME = "PostEventHandler";


### PR DESCRIPTION

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[F2F-XXX] PR Title` -->

## Proposed changes

### What changed

Updating our session store with postoffice visit timing details that we receive from F2F_DOCUMENT_UPLOADED TXMA event.
Updating the session store with the PO address and documentType and documentExpiryDate fields by consuming these values from F2F_YOTI_START and IPV_F2F_CRI_VC_CONSUMED TXMA events.
Unit-tests added to test all cases.
Evidence (Both success and negative cases) attached to the ticket for reference.
### Why did it change

Post go-live enhancement requirement

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [F2F-1061](https://govukverify.atlassian.net/browse/F2F-1061)

## Checklists

### PII logging

- [x] Verified that no PII data is being logged

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [x] No environment variables or secrets were added or changed



[F2F-1061]: https://govukverify.atlassian.net/browse/F2F-1061?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ