### PR TITLE
F2F-1194: API test container ECR Repository and Github Workflow

### DIFF
--- a/.github/workflows/post-merge-push-test-container-to-build.yml
+++ b/.github/workflows/post-merge-push-test-container-to-build.yml
@@ -1,0 +1,58 @@
+name: Deploy Test Container to Build ECR
+on:
+  # Triggers the workflow on push or pull request events but only for the "main" branch
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - 'infra-l2-dynamo/**'
+      - 'infra-l2-kms/**'
+      - 'gov-notify-stub/**'
+      - 'test-harness/**'
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+permissions:
+  id-token: write
+  contents: read
+
+env: # Only adding the variables in that are required for 
+  AWS_REGION: eu-west-2
+
+jobs:
+  deploy-test-container-to-build-ecr:
+    name: Validate & Deploy Test Container to Build Environment ECR
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v3
+
+      - name: Assume temporary AWS role
+        uses: aws-actions/configure-aws-credentials@v1-node16
+        with:
+          role-to-assume: ${{ secrets.BUILD_RETURN_GH_ACTIONS_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      # ... Build and validate SAM application ...
+
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v1
+
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@main
+        with:
+          cosign-release: 'v1.9.0'
+
+      - name: Build, tag, and push testing image to Amazon ECR
+        env:
+          BUILD_CONTAINER_SIGN_KMS_KEY: ${{ secrets.BUILD_CONTAINER_SIGN_KMS_KEY }}
+          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          BUILD_TEST_ECR_REPOSITORY: ${{ secrets.BUILD_TEST_ECR_REPOSITORY }}
+          IMAGE_TAG: latest
+        run: |
+          docker build -t $ECR_REGISTRY/$BUILD_TEST_ECR_REPOSITORY:$IMAGE_TAG .
+          docker push $ECR_REGISTRY/$BUILD_TEST_ECR_REPOSITORY:$IMAGE_TAG
+          cosign sign --key awskms:///${BUILD_CONTAINER_SIGN_KMS_KEY} $ECR_REGISTRY/$BUILD_TEST_ECR_REPOSITORY:$IMAGE_TAG
+
+      # ... Push build artefacts to S3 ...

--- a/.github/workflows/post-merge-push-test-container-to-dev.yml
+++ b/.github/workflows/post-merge-push-test-container-to-dev.yml
@@ -1,0 +1,58 @@
+name: Deploy Test Container to Dev ECR
+on:
+  # Triggers the workflow on push or pull request events but only for the "main" branch
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - 'infra-l2-dynamo/**'
+      - 'infra-l2-kms/**'
+      - 'gov-notify-stub/**'
+      - 'test-harness/**'
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+permissions:
+  id-token: write
+  contents: read
+
+env: # Only adding the variables in that are required for 
+  AWS_REGION: eu-west-2
+
+jobs:
+  deploy-test-container-to-dev-ecr:
+    name: Validate & Deploy Test Container to Dev Environment ECR
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v3
+
+      - name: Assume temporary AWS role
+        uses: aws-actions/configure-aws-credentials@v1-node16
+        with:
+          role-to-assume: ${{ secrets.DEV_RETURN_GH_ACTIONS_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      # ... Build and validate SAM application ...
+
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v1
+
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@main
+        with:
+          cosign-release: 'v1.9.0'
+
+      - name: Build, tag, and push testing image to Amazon ECR
+        env:
+          DEV_CONTAINER_SIGN_KMS_KEY: ${{ secrets.DEV_CONTAINER_SIGN_KMS_KEY }}
+          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          DEV_TEST_ECR_REPOSITORY: ${{ secrets.DEV_TEST_ECR_REPOSITORY }}
+          IMAGE_TAG: latest
+        run: |
+          docker build -t $ECR_REGISTRY/$DEV_TEST_ECR_REPOSITORY:$IMAGE_TAG .
+          docker push $ECR_REGISTRY/$DEV_TEST_ECR_REPOSITORY:$IMAGE_TAG
+          # cosign sign --key awskms:///${DEV_CONTAINER_SIGN_KMS_KEY} $ECR_REGISTRY/$DEV_TEST_ECR_REPOSITORY:$IMAGE_TAG
+
+      # ... Push build artefacts to S3 ...


### PR DESCRIPTION
- This is a fix for the api pipeline failure due to the API test ECR failure
- With the test container enabled, there is no test image available on the ECR registry. 
- Created the workflow to build the test images and push into the ECR registery


- [F2F-1194](https://govukverify.atlassian.net/browse/F2F-1194)



[F2F-1194]: https://govukverify.atlassian.net/browse/F2F-1194?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ