### PR TITLE
F2F-1129: Fix PostEventFunction to consume event from MockTxMASQSQueue

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -497,7 +497,7 @@ Resources:
                 - "kms:Decrypt"
               Resource: !If
                 - IsMockedEnvironment
-                - !GetAtt MockTxMASQSQueue.Arn
+                - !GetAtt MockTxMAKMSEncryptionKey.Arn
                 - !FindInMap [PlatformConfiguration, !Ref Environment, TxMAKey]
             - Sid: TxMASQSConsumeEventPolicy
               Effect: Allow
@@ -1322,6 +1322,7 @@ Resources:
             Principal:
               AWS: arn:aws:iam::330163506186:root
             Action:
+              - "kms:Encrypt"
               - "kms:Decrypt"
               - "kms:GenerateDataKey"
             Resource:


### PR DESCRIPTION
- Performance test had issues with MockTxMASQSQueue injected data. Any data injected was not consumed by the post event function and send to DLQ
- Fix the MockTxMAEncryption keys for the dev and build environment

- [F2F-1129](https://govukverify.atlassian.net/browse/F2F-1129)
