### PR TITLE
[KIWI-1105] Adds missing env vars to test scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ bin-release/
 /.env
 /docker_vars.env
 results/
+cf-output.txt

--- a/run-tests-locally.sh
+++ b/run-tests-locally.sh
@@ -24,6 +24,7 @@ then
     echo AWS_ACCESS_KEY_ID="$AWS_ACCESS_KEY_ID" >> docker_vars.env
     echo AWS_SECRET_ACCESS_KEY="$AWS_SECRET_ACCESS_KEY" >> docker_vars.env
     echo AWS_SESSION_TOKEN="$AWS_SESSION_TOKEN" >> docker_vars.env
+    echo AWS_REGION="$AWS_REGION" >> docker_vars.env
 
     #clean existing container and image before creating a new one
     echo "Removing existing containers and images for the test"

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -13,8 +13,10 @@ export API_TEST_SESSION_EVENTS_TABLE=$(remove_quotes $CFN_SessionEventsTable)
 # shellcheck disable=SC2154
 #The CFN variables seem to include quotes when used in tests these must be removed before assigning them.
 export API_TEST_SQS_TXMA_CONSUMER_QUEUE=$(remove_quotes $CFN_MockTxMASQSQueueUrl)
-export DEV_IPR_TEST_HARNESS_URL=$(remove_quotes $CFN_IpvReturnTestHarnessURL)
 export GOVUKNOTIFYAPI=$(remove_quotes $CFN_GovNotifyAPIURL)
+export API_TEST_SQS_TXMA_CONSUMER_QUEUE=$(remove_quotes $CFN_MockTxMASQSQueue)
+export API_TEST_GOV_NOTIFY_SQS_QUEUE=$(remove_quotes $CFN_GovNotifySQSQueue)
+export API_TEST_SESSION_EVENTS_TABLE=$(remove_quotes $CFN_SessionEventsTable)
 
 cd /src; npm run test:api
 error_code=$?

--- a/src/tests/api/postEventStream.test.ts
+++ b/src/tests/api/postEventStream.test.ts
@@ -18,7 +18,7 @@ describe("post event processor", () => {
 	});
 
 	it("when all 3 events are sent, a Dynamo record with the details of all three events populated", async () => {
-    	await postMockEvent(VALID_AUTH_IPV_AUTHORISATION_REQUESTED_TXMA_EVENT, userId, true);
+		await postMockEvent(VALID_AUTH_IPV_AUTHORISATION_REQUESTED_TXMA_EVENT, userId, true);
 		await postMockEvent(VALID_F2F_YOTI_START_TXMA_EVENT, userId, false);
 		await postMockEvent(VALID_IPV_F2F_CRI_VC_CONSUMED_TXMA_EVENT, userId, false);
 


### PR DESCRIPTION
## Proposed changes

### What changed

Adds missing env vars to test scripts

### Why did it change

Test script was failing to run

### Screenshots 

Before
![image](https://github.com/alphagov/di-ipvreturn-api/assets/40401118/66d7cd00-4352-4010-b16f-21c1ba24cf49)

After
![image](https://github.com/alphagov/di-ipvreturn-api/assets/40401118/84630917-780a-44aa-8809-8428899c5c8a)


### Issue tracking
- [F2F-1105](https://govukverify.atlassian.net/browse/F2F-1105)

## Checklists

### PII logging

- [x] Verified that no PII data is being logged
