### PR TITLE
KIWI-1105 credentials

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,13 @@ FROM ubuntu:latest
 RUN apt update -y && apt upgrade -y
 RUN apt install -y curl unzip
 
-RUN curl -sL https://deb.nodesource.com/setup_18.x | bash -
-RUN apt install -y nodejs
+RUN apt-get install -y ca-certificates curl gnupg
+RUN mkdir -p /etc/apt/keyrings
+RUN curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
+ENV NODE_MAJOR=18
+RUN echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_MAJOR.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list
+RUN apt-get update
+RUN apt-get install nodejs -y
 
 RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
 RUN unzip awscliv2.zip

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -14,7 +14,7 @@ export GOVUKNOTIFYAPI=$(remove_quotes $CFN_GovNotifyAPIURL)
 export API_TEST_SQS_TXMA_CONSUMER_QUEUE=$(remove_quotes $CFN_MockTxMASQSQueue)
 export API_TEST_GOV_NOTIFY_SQS_QUEUE=$(remove_quotes $CFN_GovNotifySQSQueue)
 export API_TEST_SESSION_EVENTS_TABLE=$(remove_quotes $CFN_SessionEventsTable)
-export DEV_IPR_TEST_HARNESS_URL="https://ipvreturn-test-harness-ccooling-1-testharness.return.dev.account.gov.uk"
+export DEV_IPR_TEST_HARNESS_URL=$(remove_quotes $CFN_IpvReturnTestHarnessURL)
 
 cd /src; npm run test:api
 error_code=$?

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -14,7 +14,7 @@ export GOVUKNOTIFYAPI=$(remove_quotes $CFN_GovNotifyAPIURL)
 export API_TEST_SQS_TXMA_CONSUMER_QUEUE=$(remove_quotes $CFN_MockTxMASQSQueue)
 export API_TEST_GOV_NOTIFY_SQS_QUEUE=$(remove_quotes $CFN_GovNotifySQSQueue)
 export API_TEST_SESSION_EVENTS_TABLE=$(remove_quotes $CFN_SessionEventsTable)
-export DEV_IPR_TEST_HARNESS_URL=$(remove_quotes $CFN_IpvReturnTestHarnessURL)
+export DEV_IPR_TEST_HARNESS_URL="https://ipvreturn-test-harness-ccooling-1-testharness.return.dev.account.gov.uk"
 
 cd /src; npm run test:api
 error_code=$?

--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -15,7 +15,7 @@
         "@aws-sdk/client-kms": "^3.352.0",
         "@aws-sdk/client-sqs": "^3.352.0",
         "@aws-sdk/client-ssm": "^3.352.0",
-        "@aws-sdk/credential-providers": "3.352.0",
+        "@aws-sdk/credential-providers": "^3.352.0",
         "@aws-sdk/lib-dynamodb": "3.150.0",
         "aws-xray-sdk-core": "^3.4.1",
         "axios": ">=1.3.4",

--- a/src/package.json
+++ b/src/package.json
@@ -12,7 +12,7 @@
     "@aws-sdk/client-kms": "^3.352.0",
     "@aws-sdk/client-sqs": "^3.352.0",
     "@aws-sdk/client-ssm": "^3.352.0",
-    "@aws-sdk/credential-providers": "3.352.0",
+    "@aws-sdk/credential-providers": "^3.352.0",
     "@aws-sdk/lib-dynamodb": "3.150.0",
     "aws-xray-sdk-core": "^3.4.1",
     "axios": ">=1.3.4",

--- a/src/tests/api/utils/ApiTestSteps.ts
+++ b/src/tests/api/utils/ApiTestSteps.ts
@@ -1,4 +1,5 @@
 import { SendMessageCommand, SendMessageCommandOutput, SQSClient, PurgeQueueCommand, ReceiveMessageCommand } from "@aws-sdk/client-sqs";
+import { fromNodeProviderChain } from "@aws-sdk/credential-providers"; 
 import axios, { AxiosInstance } from "axios";
 import { aws4Interceptor } from "aws4-axios";
 import { randomUUID } from "crypto";
@@ -15,11 +16,19 @@ const GOV_NOTIFY_INSTANCE = axios.create({ baseURL: process.env.GOVUKNOTIFYAPI }
 
 const HARNESS_API_INSTANCE : AxiosInstance = axios.create({ baseURL: constants.DEV_IPR_TEST_HARNESS_URL });
 
+const customCredentialsProvider = {
+	getCredentials: fromNodeProviderChain({
+		timeout: 1000,
+		maxRetries: 0,
+	}),
+};
+
 const awsSigv4Interceptor = aws4Interceptor({
 	options: {
 		region: AWS_REGION,
 		service: "execute-api",
 	},
+	credentials: customCredentialsProvider,
 });
 HARNESS_API_INSTANCE.interceptors.request.use(awsSigv4Interceptor);
 const xmlParser = new XMLParser();

--- a/test-harness/test-harness-spec.yaml
+++ b/test-harness/test-harness-spec.yaml
@@ -14,24 +14,23 @@ tags:
   - name: Testing - API to enable automation
     description: Endpoint implemented to enable testing
 
-# To be re-added in KIWI-1105
-# x-amazon-apigateway-policy:
-#   Version: "2012-10-17"
-#   Statement:
-#   - Effect: "Deny"
-#     Principal:
-#       AWS:  "*"
-#     Action: "execute-api:Invoke"
-#     Resource: "execute-api:/*"
-#     Condition:
-#       StringNotEquals:
-#         "aws:PrincipalAccount":
-#           - "${AWS::AccountId}"
-#   - Effect: "Allow"
-#     Principal:
-#       AWS:  "*"
-#     Action: "execute-api:Invoke"
-#     Resource: "execute-api:/*"
+x-amazon-apigateway-policy:
+  Version: "2012-10-17"
+  Statement:
+  - Effect: "Deny"
+    Principal:
+      AWS:  "*"
+    Action: "execute-api:Invoke"
+    Resource: "execute-api:/*"
+    Condition:
+      StringNotEquals:
+        "aws:PrincipalAccount":
+          - "${AWS::AccountId}"
+  - Effect: "Allow"
+    Principal:
+      AWS:  "*"
+    Action: "execute-api:Invoke"
+    Resource: "execute-api:/*"
 
 paths:
   getRecordByUserId/{tableName}/{userId}:
@@ -68,8 +67,8 @@ paths:
           description: Unauthorized
         "500":
           description: Internal Server Error
-      # security:
-      #   - sigv4Reference: []
+      security:
+        - sigv4Reference: []
       x-amazon-apigateway-request-validator: "requestParamsOnly"
       x-amazon-apigateway-integration:
         httpMethod: POST
@@ -117,8 +116,8 @@ paths:
           description: Unauthorized
         "500":
           description: Internal Server Error
-      # security:
-      #   - sigv4Reference: []
+      security:
+        - sigv4Reference: []
       x-amazon-apigateway-request-validator: "requestParamsOnly"
       x-amazon-apigateway-integration:
         httpMethod: GET
@@ -164,8 +163,8 @@ paths:
           description: Unauthorized
         "500":
           description: Internal Server Error
-      # security:
-        # - sigv4Reference: []
+      security:
+        - sigv4Reference: []
       x-amazon-apigateway-request-validator: "both"
       x-amazon-apigateway-integration:
         httpMethod: POST
@@ -226,8 +225,8 @@ paths:
           description: Unauthorized
         "500":
           description: Internal Server Error
-      # security:
-        # - sigv4Reference: []
+      security:
+        - sigv4Reference: []
       x-amazon-apigateway-request-validator: "requestParamsOnly"
       x-amazon-apigateway-integration:
         httpMethod: GET
@@ -300,13 +299,12 @@ components:
               type: array
           description: "additional details"
 
-  # To be re-added in KIWI-1105
-  # securitySchemes:
-  #   sigv4Reference:
-  #     type: apiKey
-  #     name: Authorization
-  #     in: header
-  #     x-amazon-apigateway-authtype: awsSigv4
+  securitySchemes:
+    sigv4Reference:
+      type: apiKey
+      name: Authorization
+      in: header
+      x-amazon-apigateway-authtype: awsSigv4
 
 x-amazon-apigateway-request-validators:
     both:


### PR DESCRIPTION
## Proposed changes

### What changed

Uses AWS credential-providers to get credentials in the pipeline so that our interceptor works with sigv4

### Screenshots

Tested against test harness with enabled apigw policy 
<img width="1117" alt="image" src="https://github.com/alphagov/di-ipvreturn-api/assets/40401118/ffb509f1-40cb-4b77-a2e2-4ce1c5d71bf7">

Test pipeline step is successful 
https://eu-west-2.console.aws.amazon.com/codesuite/codepipeline/pipelines/ipvreturn-api-pipeline-Pipeline-FSPG9ANPAQVQ/view?region=eu-west-2

<img width="410" alt="image" src="https://github.com/alphagov/di-ipvreturn-api/assets/40401118/67e4ce52-e61c-43f8-abf4-3be67da78874">
<img width="585" alt="image" src="https://github.com/alphagov/di-ipvreturn-api/assets/40401118/9b172946-7e3e-4fa5-98c0-e79bf9a46a71">

### Issue tracking
- [KIWI-1105](https://govukverify.atlassian.net/browse/KIWI-1105)


[KIWI-1105]: https://govukverify.atlassian.net/browse/KIWI-1105?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ