### PR TITLE
[KIWI-1105] adds IsMockedEnvironment condition to mock txma outputs

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -2251,11 +2251,13 @@ Outputs:
     Value: !Ref MockTxMASQSQueue
     Condition: IsMockedEnvironment
   MockTxMASQSQueueArn:
+    Condition: IsMockedEnvironment
     Description: "Arn of SQS TXMA Consumer Queue"
     Value: !GetAtt MockTxMASQSQueue.Arn
     Export:
       Name: !Sub ${AWS::StackName}-MockTxMASQSQueue-arn
   MockTxMASQSQueueName:
+    Condition: IsMockedEnvironment
     Description: "Name SQS TXMA Consumer Queue"
     Value: !GetAtt MockTxMASQSQueue.QueueName
     Export:


### PR DESCRIPTION
## Proposed changes

### What changed

adds IsMockedEnvironment condition to mock txma outputs

### Why did it change

Mock txma queue is not used outside of mocked environments

### Issue tracking

- [KIWI-1105](https://govukverify.atlassian.net/browse/KIWI-1105)



[KIWI-1105]: https://govukverify.atlassian.net/browse/KIWI-1105?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ