### PR TITLE
[KIWI-1307] removes userId from log

### DIFF
--- a/src/services/IPRService.ts
+++ b/src/services/IPRService.ts
@@ -63,8 +63,8 @@ export class IPRService {
 
 		if (session.Item) {
 			if (session.Item.expiresOn < absoluteTimeNow()) {
-				this.logger.error({ message: `Session with userId: ${userId} has expired`, messageCode: MessageCodes.SESSION_EXPIRED });
-				throw new AppError( HttpCodesEnum.UNAUTHORIZED, `Session with userId: ${userId} has expired`);
+				this.logger.error({ message: "Session has expired", messageCode: MessageCodes.SESSION_EXPIRED });
+				throw new AppError( HttpCodesEnum.UNAUTHORIZED, "Session has expired");
 			}
 			return session.Item as ExtSessionEvent;
 		}

--- a/src/tests/unit/services/IPRService.test.ts
+++ b/src/tests/unit/services/IPRService.test.ts
@@ -211,8 +211,8 @@ describe("IPR Service", () => {
 				},
 			});
 
-			await expect(iprService.getSessionBySub(userId)).rejects.toThrow(new AppError( HttpCodesEnum.UNAUTHORIZED, `Session with userId: ${userId} has expired`));
-			expect(logger.error).toHaveBeenCalledWith({ message: `Session with userId: ${userId} has expired`, messageCode: MessageCodes.SESSION_EXPIRED });
+			await expect(iprService.getSessionBySub(userId)).rejects.toThrow(new AppError( HttpCodesEnum.UNAUTHORIZED, "Session has expired"));
+			expect(logger.error).toHaveBeenCalledWith({ message: "Session has expired", messageCode: MessageCodes.SESSION_EXPIRED });
 		});
 
 		it("Should throw error if dynamo get command fails", async () => {


### PR DESCRIPTION
## Proposed changes

### What changed

Removes `userId` from log

### Why did it change

`userId` is considered PII

### Screenshots


### Issue tracking

- [KIWI-1307](https://govukverify.atlassian.net/browse/KIWI-1307)

## Checklists

### PII logging

- [x] Verified that no PII data is being logged

