### PR TITLE
[KIWI-2609] - Axios upgrade

### DIFF
--- a/gov-notify-stub/src/package-lock.json
+++ b/gov-notify-stub/src/package-lock.json
@@ -12,7 +12,7 @@
         "@aws-lambda-powertools/logger": "1.5.1",
         "@aws-lambda-powertools/metrics": "1.5.1",
         "aws-xray-sdk-core": "3.10.3",
-        "axios": "1.13.5",
+        "axios": "1.15.0",
         "esbuild": "0.25.2"
       },
       "devDependencies": {
@@ -1129,14 +1129,14 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.13.5",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.5.tgz",
-      "integrity": "sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
+      "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.11",
         "form-data": "^4.0.5",
-        "proxy-from-env": "^1.1.0"
+        "proxy-from-env": "^2.1.0"
       }
     },
     "node_modules/balanced-match": {
@@ -2128,10 +2128,13 @@
       }
     },
     "node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-      "license": "MIT"
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/punycode": {
       "version": "2.3.1",

--- a/gov-notify-stub/src/package.json
+++ b/gov-notify-stub/src/package.json
@@ -9,7 +9,7 @@
     "@aws-lambda-powertools/logger": "1.5.1",
     "@aws-lambda-powertools/metrics": "1.5.1",
     "aws-xray-sdk-core": "3.10.3",
-    "axios": "1.13.5",
+    "axios": "1.15.0",
     "esbuild": "0.25.2"
   },
   "scripts": {

--- a/oidc-stub/src/package-lock.json
+++ b/oidc-stub/src/package-lock.json
@@ -14,7 +14,7 @@
         "@aws-sdk/client-kms": "3.1001.0",
         "@smithy/node-http-handler": "4.0.4",
         "aws-xray-sdk-core": "3.10.3",
-        "axios": "1.13.5",
+        "axios": "1.15.0",
         "class-validator": "0.14.1",
         "ecdsa-sig-formatter": "1.0.11",
         "esbuild": "0.25.2",
@@ -2691,14 +2691,14 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.13.5",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.5.tgz",
-      "integrity": "sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
+      "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.11",
         "form-data": "^4.0.5",
-        "proxy-from-env": "^1.1.0"
+        "proxy-from-env": "^2.1.0"
       }
     },
     "node_modules/balanced-match": {
@@ -4290,10 +4290,13 @@
       }
     },
     "node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-      "license": "MIT"
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/punycode": {
       "version": "2.3.1",

--- a/oidc-stub/src/package.json
+++ b/oidc-stub/src/package.json
@@ -11,7 +11,7 @@
     "@aws-sdk/client-kms": "3.1001.0",
     "@smithy/node-http-handler": "4.0.4",
     "aws-xray-sdk-core": "3.10.3",
-    "axios": "1.13.5",
+    "axios": "1.15.0",
     "class-validator": "0.14.1",
     "ecdsa-sig-formatter": "1.0.11",
     "esbuild": "0.25.2",

--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -21,7 +21,7 @@
         "@aws-sdk/util-dynamodb": "3.984.0",
         "@smithy/node-http-handler": "4.0.4",
         "aws-xray-sdk-core": "3.10.3",
-        "axios": "1.13.5",
+        "axios": "1.15.0",
         "class-validator": "0.14.1",
         "ecdsa-sig-formatter": "1.0.11",
         "esbuild": "0.25.2",
@@ -5922,14 +5922,14 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.13.5",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.5.tgz",
-      "integrity": "sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
+      "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.11",
         "form-data": "^4.0.5",
-        "proxy-from-env": "^1.1.0"
+        "proxy-from-env": "^2.1.0"
       }
     },
     "node_modules/babel-jest": {
@@ -11357,10 +11357,13 @@
       }
     },
     "node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-      "license": "MIT"
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/punycode": {
       "version": "2.3.1",

--- a/src/package.json
+++ b/src/package.json
@@ -18,7 +18,7 @@
     "@aws-sdk/util-dynamodb": "3.984.0",
     "@smithy/node-http-handler": "4.0.4",
     "aws-xray-sdk-core": "3.10.3",
-    "axios": "1.13.5",
+    "axios": "1.15.0",
     "class-validator": "0.14.1",
     "ecdsa-sig-formatter": "1.0.11",
     "esbuild": "0.25.2",


### PR DESCRIPTION

## Proposed changes

### What changed

Bumped Axios from 1.13.5 -> 1.15.0

### Why did it change

To address critical vulnerabilities

### Issue tracking

- [KIWI-2609](https://govukverify.atlassian.net/browse/KIWI-2609)

[KIWI-2609]: https://govukverify.atlassian.net/browse/KIWI-2609?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ