### PR TITLE
[KIWI-2634] - Clean up unused env variables of pull request workflow

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -26,7 +26,6 @@ permissions:
 
 env: # Only adding the variables in that are required for
   AWS_REGION: eu-west-2
-  DEV_IPR_GOV_NOTIFY_STUB_URL: ${{ secrets.DEV_IPR_GOV_NOTIFY_STUB_URL }}
 
 jobs:
   run-code-check:

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -133,7 +133,7 @@
         "filename": ".github/workflows/pull-request.yml",
         "hashed_secret": "3e26d6750975d678acb8fa35a0f69237881576b0",
         "is_verified": false,
-        "line_number": 121
+        "line_number": 120
       }
     ],
     "src/tests/unit/services/PostEventProcessor.test.ts": [
@@ -167,5 +167,5 @@
       }
     ]
   },
-  "generated_at": "2026-01-23T14:34:48Z"
+  "generated_at": "2026-04-28T20:04:48Z"
 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[KIWI-XXXX] PR Title` -->

## Proposed changes

### What changed

Removed unused env variables of pull request workflow

- DEV_IPR_GOV_NOTIFY_STUB_URL

### Why did it change

To ensure code standards

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [KIWI-2634](https://govukverify.atlassian.net/browse/KIWI-2634)



[KIWI-2634]: https://govukverify.atlassian.net/browse/KIWI-2634?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ