### PR TITLE
[KIWI-2730] - IPR | BE | Local .env file inaccessible to tests post-Vitest migration

### DIFF
--- a/src/vitest.config.ts
+++ b/src/vitest.config.ts
@@ -1,7 +1,5 @@
-import dotenv from "dotenv";
+import 'dotenv/config';
 import { defineConfig } from "vitest/config";
-
-dotenv.config();
 
 export default defineConfig({
   test: {

--- a/src/vitest.config.ts
+++ b/src/vitest.config.ts
@@ -1,4 +1,7 @@
+import dotenv from "dotenv";
 import { defineConfig } from "vitest/config";
+
+dotenv.config();
 
 export default defineConfig({
   test: {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[KIWI-XXXX] PR Title` -->

## Proposed changes

### What changed

dotenv.config() added to vitest.config file

### Why did it change

To make local environment variables usable

### Local test run output

<img width="705" height="86" alt="Screenshot 2026-06-05 at 12 16 19" src="https://github.com/user-attachments/assets/9dddd18e-4dfd-44f0-a65a-0a02f6e21831" />


